### PR TITLE
Fix typo in SaveLocation property

### DIFF
--- a/Lantean.QBitTorrentClient/Converters/SaveLocationJsonConverter.cs
+++ b/Lantean.QBitTorrentClient/Converters/SaveLocationJsonConverter.cs
@@ -27,7 +27,7 @@ namespace Lantean.QBitTorrentClient.Converters
             {
                 writer.WriteNumberValue(0);
             }
-            else if (value.IsDefaltFolder)
+            else if (value.IsDefaultFolder)
             {
                 writer.WriteNumberValue(1);
             }

--- a/Lantean.QBitTorrentClient/Models/SaveLocation.cs
+++ b/Lantean.QBitTorrentClient/Models/SaveLocation.cs
@@ -4,7 +4,7 @@
     {
         public bool IsWatchedFolder { get; set; }
 
-        public bool IsDefaltFolder { get; set; }
+        public bool IsDefaultFolder { get; set; }
 
         public string? SavePath { get; set; }
 
@@ -23,7 +23,7 @@
                 {
                     return new SaveLocation
                     {
-                        IsDefaltFolder = true
+                        IsDefaultFolder = true
                     };
                 }
             }
@@ -40,7 +40,7 @@
                 {
                     return new SaveLocation
                     {
-                        IsDefaltFolder = true
+                        IsDefaultFolder = true
                     };
                 }
                 else
@@ -61,7 +61,7 @@
             {
                 return 0;
             }
-            else if (IsDefaltFolder)
+            else if (IsDefaultFolder)
             {
                 return 1;
             }


### PR DESCRIPTION
## Summary
- correct `IsDefaltFolder` typo in SaveLocation
- update SaveLocationJsonConverter accordingly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ea9d2a488832f9b05fe807f9c0930