### PR TITLE
Fix MaxRatio to allow float values

### DIFF
--- a/Lantean.QBTMud/Components/Options/BitTorrentOptions.razor
+++ b/Lantean.QBTMud/Components/Options/BitTorrentOptions.razor
@@ -92,7 +92,9 @@
                 <FieldSwitch Label="When ratio reaches" Value="MaxRatioEnabled" ValueChanged="MaxRatioEnabledChanged" />
             </MudItem>
             <MudItem xs="9">
-                <MudNumericField T="int" Label="" Value="MaxRatio" ValueChanged="MaxRatioChanged" Disabled="@(!MaxRatioEnabled)" Min="0" Max="9998" Variant="Variant.Outlined" Validation="MaxRatioValidation" />
+                <MudNumericField T="float" Label="" Value="MaxRatio" ValueChanged="MaxRatioChanged"
+                    Disabled="@(!MaxRatioEnabled)" Min="0" Max="9998" Variant="Variant.Outlined"
+                    Validation="MaxRatioValidation" />
             </MudItem>
             <MudItem xs="3">
                 <FieldSwitch Label="When total seeding time reaches" Value="MaxSeedingTimeEnabled" ValueChanged="MaxSeedingTimeEnabledChanged" />

--- a/Lantean.QBTMud/Components/Options/BitTorrentOptions.razor.cs
+++ b/Lantean.QBTMud/Components/Options/BitTorrentOptions.razor.cs
@@ -17,7 +17,7 @@
         protected int SlowTorrentUlRateThreshold { get; private set; }
         protected int SlowTorrentInactiveTimer { get; private set; }
         protected bool MaxRatioEnabled { get; private set; }
-        protected int MaxRatio { get; private set; }
+        protected float MaxRatio { get; private set; }
         protected bool MaxSeedingTimeEnabled { get; private set; }
         protected int MaxSeedingTime { get; private set; }
         protected int MaxRatioAct { get; private set; }
@@ -275,7 +275,7 @@
             await PreferencesChanged.InvokeAsync(UpdatePreferences);
         }
 
-        protected async Task MaxRatioChanged(int value)
+        protected async Task MaxRatioChanged(float value)
         {
             MaxRatio = value;
             UpdatePreferences.MaxRatio = value;

--- a/Lantean.QBitTorrentClient/Models/Preferences.cs
+++ b/Lantean.QBitTorrentClient/Models/Preferences.cs
@@ -112,7 +112,7 @@ namespace Lantean.QBitTorrentClient.Models
             int maxConnecPerTorrent,
             int maxInactiveSeedingTime,
             bool maxInactiveSeedingTimeEnabled,
-            int maxRatio,
+            float maxRatio,
             int maxRatioAct,
             bool maxRatioEnabled,
             int maxSeedingTime,
@@ -745,7 +745,7 @@ namespace Lantean.QBitTorrentClient.Models
         public bool MaxInactiveSeedingTimeEnabled { get; }
 
         [JsonPropertyName("max_ratio")]
-        public int MaxRatio { get; }
+        public float MaxRatio { get; }
 
         [JsonPropertyName("max_ratio_act")]
         public int MaxRatioAct { get; }

--- a/Lantean.QBitTorrentClient/Models/UpdatePreferences.cs
+++ b/Lantean.QBitTorrentClient/Models/UpdatePreferences.cs
@@ -323,7 +323,7 @@ namespace Lantean.QBitTorrentClient.Models
         public bool? MaxInactiveSeedingTimeEnabled { get; set; }
 
         [JsonPropertyName("max_ratio")]
-        public int? MaxRatio { get; set; }
+        public float? MaxRatio { get; set; }
 
         [JsonPropertyName("max_ratio_act")]
         public int? MaxRatioAct { get; set; }

--- a/readme.md
+++ b/readme.md
@@ -68,10 +68,12 @@ cd qbtmud
 dotnet restore
 ```
 
-### 3. Build the Application
+### 3. Build and Publish the Application
 ```sh
-dotnet build --configuration Release
+dotnet publish --configuration Release
 ```
+
+This will output the Web UI files to `Lantean.QBTMud\bin\Release\net9.0\publish\wwwroot`.
 
 ### 4. Configure qBittorrent to Use qbtmud
 Follow the same steps as in the **Installation** section to set qbtmud as your WebUI.


### PR DESCRIPTION
I use a max ratio value of 1.1 and when using this UI I get a bunch of failures and then the client crashes.  The issue is that MaxRatio was an `int` but qBittorrent supports float values. for that field.  This PR changes the value to float.  I manually verified that this fixed my issues with UI startup and I am able to render the BitTorrent section of the settings page.