### PR TITLE
Feature/bugfixes

### DIFF
--- a/Lantean.QBTMud/Components/Options/DownloadsOptions.razor
+++ b/Lantean.QBTMud/Components/Options/DownloadsOptions.razor
@@ -62,7 +62,7 @@
     <MudCardContent Class="pt-0">
         <MudGrid>
             <MudItem xs="12">
-                <MudSelect T="bool" Label="Default Torrent Management Mode" Value="AutoTmmEnabled" ValueChanged="AutoDeleteModeChanged" Variant="Variant.Outlined">
+                <MudSelect T="bool" Label="Default Torrent Management Mode" Value="AutoTmmEnabled" ValueChanged="AutoTmmEnabledChanged" Variant="Variant.Outlined">
                     <MudSelectItem Value="false">Manual</MudSelectItem>
                     <MudSelectItem Value="true">Automatic</MudSelectItem>
                 </MudSelect>

--- a/Lantean.QBTMud/Helpers/DisplayHelpers.cs
+++ b/Lantean.QBTMud/Helpers/DisplayHelpers.cs
@@ -25,7 +25,7 @@ namespace Lantean.QBTMud.Helpers
             const long InfiniteEtaSentinelSeconds = 8_640_000; // ~100 days, used by qBittorrent for "infinite" ETA.
             var value = seconds.Value;
 
-            if (value >= long.MaxValue || value >= (long)TimeSpan.MaxValue.TotalSeconds || value == InfiniteEtaSentinelSeconds)
+            if (value >= long.MaxValue || value >= TimeSpan.MaxValue.TotalSeconds || value == InfiniteEtaSentinelSeconds)
             {
                 return "∞";
             }

--- a/Lantean.QBTMud/Helpers/FilterHelper.cs
+++ b/Lantean.QBTMud/Helpers/FilterHelper.cs
@@ -207,7 +207,7 @@ namespace Lantean.QBTMud.Helpers
                     break;
 
                 case Status.Paused:
-                    if (!state.Contains("paused") || !state.Contains("stopped"))
+                    if (!state.Contains("paused") && !state.Contains("stopped"))
                     {
                         return false;
                     }

--- a/Lantean.QBTMud/Services/DataManager.cs
+++ b/Lantean.QBTMud/Services/DataManager.cs
@@ -220,12 +220,11 @@ namespace Lantean.QBTMud.Services
                     }
 
                     torrentList.Tags.Add(normalizedTag);
-                    if (!torrentList.TagState.ContainsKey(normalizedTag))
-                    {
-                        torrentList.TagState[normalizedTag] = torrentList.Torrents.Values
-                            .Where(t => FilterHelper.FilterTag(t, normalizedTag))
-                            .ToHashesHashSet();
-                    }
+                    var matchingHashes = torrentList.Torrents
+                        .Where(pair => FilterHelper.FilterTag(pair.Value, normalizedTag))
+                        .Select(pair => pair.Key)
+                        .ToHashSet();
+                    torrentList.TagState[normalizedTag] = matchingHashes;
                 }
             }
 


### PR DESCRIPTION
- Fixed an issue where the tag wasn't being correctly applied to the filter in qBittorrent 5.1+ (#9)
- Fixed an issue where the category wasn't being applied to the filter correctly (#9)
- Fixed invalid ValueChanged for "Default Torrent Management Mode"
- Fixed a crash where TimeSpan.FromSeconds was crashing
- Fixed an invalid icon to appear when Paused/Stopped