### PR TITLE
Fix for Inefficient use of ContainsKey

### DIFF
--- a/src/Lantean.QBTMud/Components/UI/DynamicTable.razor.cs
+++ b/src/Lantean.QBTMud/Components/UI/DynamicTable.razor.cs
@@ -928,7 +928,8 @@ namespace Lantean.QBTMud.Components.UI
 
         private static bool DictionaryEqual<TKey, TValue>(Dictionary<TKey, TValue> left, Dictionary<TKey, TValue> right) where TKey : notnull
         {
-            return left.Keys.Count == right.Keys.Count && left.Keys.All(k => right.ContainsKey(k) && Equals(left[k], right[k]));
+            return left.Keys.Count == right.Keys.Count &&
+                   left.Keys.All(k => right.TryGetValue(k, out var rightValue) && Equals(left[k], rightValue));
         }
 
         private static string? GetColumnStyle(ColumnDefinition<T> column)


### PR DESCRIPTION
To fix the issue, we should replace the pattern that first calls `ContainsKey` and then uses the indexer with a single `TryGetValue` call. This combines the existence check and retrieval into one dictionary lookup, which is both more efficient and directly satisfies the CodeQL rule.

Concretely, in `DictionaryEqual`, instead of:

```csharp
left.Keys.All(k => right.ContainsKey(k) && Equals(left[k], right[k]))
```

we will introduce a lambda that calls `right.TryGetValue(k, out var rightValue)` and, if successful, compares `left[k]` to `rightValue`. This preserves the semantics (only consider dictionaries equal if `right` has all keys in `left` and the associated values are equal) while eliminating the redundant lookup. The left-hand lookup `left[k]` is still needed and is not part of the reported anti-pattern.

No new methods or imports are required. Only the body of `DictionaryEqual` in `src/Lantean.QBTMud/Components/UI/DynamicTable.razor.cs` needs to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._