### PR TITLE
Remove dependency on UI feedback

### DIFF
--- a/src/Lantean.QBTMud/Services/ClientDataLoadResult.cs
+++ b/src/Lantean.QBTMud/Services/ClientDataLoadResult.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Services
 {
@@ -10,12 +11,18 @@ namespace Lantean.QBTMud.Services
         /// <summary>
         /// Gets a failed ClientData load result.
         /// </summary>
-        public static ClientDataLoadResult Failure { get; } = new(false, null);
+        public static ClientDataLoadResult Failure { get; } = new(false, null, null);
 
-        private ClientDataLoadResult(bool succeeded, IReadOnlyDictionary<string, JsonElement>? entries)
+        private ClientDataLoadResult(bool succeeded, IReadOnlyDictionary<string, JsonElement>? entries, ApiResultBase? failureResult)
         {
+            if (failureResult is not null && !failureResult.IsFailure)
+            {
+                throw new ArgumentException("FailureResult must be a failed API result.", nameof(failureResult));
+            }
+
             Succeeded = succeeded;
             Entries = entries;
+            FailureResult = failureResult;
         }
 
         /// <summary>
@@ -29,13 +36,30 @@ namespace Lantean.QBTMud.Services
         public IReadOnlyDictionary<string, JsonElement>? Entries { get; }
 
         /// <summary>
+        /// Gets the failed API result that caused the ClientData load operation to fail.
+        /// </summary>
+        public ApiResultBase? FailureResult { get; }
+
+        /// <summary>
         /// Creates a successful ClientData load result.
         /// </summary>
         /// <param name="entries">The loaded ClientData entries.</param>
         /// <returns>The successful ClientData load result.</returns>
         public static ClientDataLoadResult FromEntries(IReadOnlyDictionary<string, JsonElement> entries)
         {
-            return new ClientDataLoadResult(true, entries);
+            return new ClientDataLoadResult(true, entries, null);
+        }
+
+        /// <summary>
+        /// Creates a failed ClientData load result from a failed API result.
+        /// </summary>
+        /// <param name="failureResult">The failed API result.</param>
+        /// <returns>The failed ClientData load result.</returns>
+        public static ClientDataLoadResult FromFailure(ApiResultBase failureResult)
+        {
+            ArgumentNullException.ThrowIfNull(failureResult);
+
+            return new ClientDataLoadResult(false, null, failureResult);
         }
     }
 }

--- a/src/Lantean.QBTMud/Services/ClientDataStorageAdapter.cs
+++ b/src/Lantean.QBTMud/Services/ClientDataStorageAdapter.cs
@@ -14,17 +14,14 @@ namespace Lantean.QBTMud.Services
         public const string StorageKeyPrefix = "QbtMud.";
 
         private readonly IApiClient _apiClient;
-        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientDataStorageAdapter"/> class.
         /// </summary>
         /// <param name="apiClient">The qBittorrent API client.</param>
-        /// <param name="apiFeedbackWorkflow">The API feedback workflow.</param>
-        public ClientDataStorageAdapter(IApiClient apiClient, IApiFeedbackWorkflow apiFeedbackWorkflow)
+        public ClientDataStorageAdapter(IApiClient apiClient)
         {
             _apiClient = apiClient;
-            _apiFeedbackWorkflow = apiFeedbackWorkflow;
         }
 
         /// <inheritdoc />
@@ -49,8 +46,7 @@ namespace Lantean.QBTMud.Services
             var loadedResult = await _apiClient.LoadClientDataAsync(normalizedKeys, cancellationToken);
             if (loadedResult.IsFailure)
             {
-                await _apiFeedbackWorkflow.HandleFailureAsync(loadedResult, cancellationToken: cancellationToken);
-                return ClientDataLoadResult.Failure;
+                return ClientDataLoadResult.FromFailure(loadedResult);
             }
 
             var loadedData = loadedResult.Value;
@@ -68,8 +64,7 @@ namespace Lantean.QBTMud.Services
             var loadedResult = await _apiClient.LoadClientDataAsync(keys: null, cancellationToken);
             if (loadedResult.IsFailure)
             {
-                await _apiFeedbackWorkflow.HandleFailureAsync(loadedResult, cancellationToken: cancellationToken);
-                return ClientDataLoadResult.Failure;
+                return ClientDataLoadResult.FromFailure(loadedResult);
             }
 
             var loadedData = loadedResult.Value;
@@ -102,9 +97,9 @@ namespace Lantean.QBTMud.Services
                 StringComparer.Ordinal);
 
             var storeResult = await _apiClient.StoreClientDataAsync(payload, cancellationToken);
-            if (!await _apiFeedbackWorkflow.ProcessResultAsync(storeResult, cancellationToken: cancellationToken))
+            if (storeResult.IsFailure)
             {
-                return ClientDataStorageResult.Failure;
+                return ClientDataStorageResult.FromFailure(storeResult);
             }
 
             return ClientDataStorageResult.Success;
@@ -135,9 +130,9 @@ namespace Lantean.QBTMud.Services
         private async Task<ClientDataStorageResult> RemovePrefixedEntriesCoreAsync(IReadOnlyCollection<string> removalKeys, CancellationToken cancellationToken)
         {
             var removeResult = await _apiClient.DeleteClientDataAsync(removalKeys, cancellationToken);
-            if (!await _apiFeedbackWorkflow.ProcessResultAsync(removeResult, cancellationToken: cancellationToken))
+            if (removeResult.IsFailure)
             {
-                return ClientDataStorageResult.Failure;
+                return ClientDataStorageResult.FromFailure(removeResult);
             }
 
             return ClientDataStorageResult.Success;

--- a/src/Lantean.QBTMud/Services/ClientDataStorageResult.cs
+++ b/src/Lantean.QBTMud/Services/ClientDataStorageResult.cs
@@ -1,3 +1,5 @@
+using QBittorrent.ApiClient;
+
 namespace Lantean.QBTMud.Services
 {
     /// <summary>
@@ -8,21 +10,44 @@ namespace Lantean.QBTMud.Services
         /// <summary>
         /// Gets a successful ClientData storage result.
         /// </summary>
-        public static ClientDataStorageResult Success { get; } = new(true);
+        public static ClientDataStorageResult Success { get; } = new(true, null);
 
         /// <summary>
         /// Gets a failed ClientData storage result.
         /// </summary>
-        public static ClientDataStorageResult Failure { get; } = new(false);
+        public static ClientDataStorageResult Failure { get; } = new(false, null);
 
-        private ClientDataStorageResult(bool succeeded)
+        private ClientDataStorageResult(bool succeeded, ApiResultBase? failureResult)
         {
+            if (failureResult is not null && !failureResult.IsFailure)
+            {
+                throw new ArgumentException("FailureResult must be a failed API result.", nameof(failureResult));
+            }
+
             Succeeded = succeeded;
+            FailureResult = failureResult;
         }
 
         /// <summary>
         /// Gets a value indicating whether the operation succeeded.
         /// </summary>
         public bool Succeeded { get; }
+
+        /// <summary>
+        /// Gets the failed API result that caused the ClientData storage operation to fail.
+        /// </summary>
+        public ApiResultBase? FailureResult { get; }
+
+        /// <summary>
+        /// Creates a failed ClientData storage result from a failed API result.
+        /// </summary>
+        /// <param name="failureResult">The failed API result.</param>
+        /// <returns>The failed ClientData storage result.</returns>
+        public static ClientDataStorageResult FromFailure(ApiResultBase failureResult)
+        {
+            ArgumentNullException.ThrowIfNull(failureResult);
+
+            return new ClientDataStorageResult(false, failureResult);
+        }
     }
 }

--- a/src/Lantean.QBTMud/Services/SettingsStorageService.cs
+++ b/src/Lantean.QBTMud/Services/SettingsStorageService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Lantean.QBTMud.Models;
 using Lantean.QBTMud.Theming;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Services
 {
@@ -15,6 +16,7 @@ namespace Lantean.QBTMud.Services
         private readonly IStorageRoutingService _storageRoutingService;
         private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SettingsStorageService"/> class.
@@ -23,16 +25,19 @@ namespace Lantean.QBTMud.Services
         /// <param name="storageRoutingService">The storage routing service.</param>
         /// <param name="webApiCapabilityService">The Web API capability service.</param>
         /// <param name="clientDataStorageAdapter">The client data storage adapter.</param>
+        /// <param name="apiFeedbackWorkflow">The API feedback workflow.</param>
         public SettingsStorageService(
             ILocalStorageService localStorageService,
             IStorageRoutingService storageRoutingService,
             IWebApiCapabilityService webApiCapabilityService,
-            IClientDataStorageAdapter clientDataStorageAdapter)
+            IClientDataStorageAdapter clientDataStorageAdapter,
+            IApiFeedbackWorkflow apiFeedbackWorkflow)
         {
             _localStorageService = localStorageService;
             _storageRoutingService = storageRoutingService;
             _webApiCapabilityService = webApiCapabilityService;
             _clientDataStorageAdapter = clientDataStorageAdapter;
+            _apiFeedbackWorkflow = apiFeedbackWorkflow;
         }
 
         /// <inheritdoc />
@@ -52,6 +57,7 @@ namespace Lantean.QBTMud.Services
                 var loadedResult = await _clientDataStorageAdapter.LoadPrefixedEntriesAsync([prefixedKey], cancellationToken);
                 if (!loadedResult.Succeeded || loadedResult.Entries is null)
                 {
+                    await HandleClientDataFailureAsync(loadedResult.FailureResult, cancellationToken);
                     return await _localStorageService.GetItemAsync<T>(key, cancellationToken);
                 }
 
@@ -86,6 +92,7 @@ namespace Lantean.QBTMud.Services
             var loadedResult = await _clientDataStorageAdapter.LoadPrefixedEntriesAsync([prefixedKey], cancellationToken);
             if (!loadedResult.Succeeded || loadedResult.Entries is null)
             {
+                await HandleClientDataFailureAsync(loadedResult.FailureResult, cancellationToken);
                 return await _localStorageService.GetItemAsStringAsync(key, cancellationToken);
             }
 
@@ -128,6 +135,7 @@ namespace Lantean.QBTMud.Services
 
             if (!storeResult.Succeeded)
             {
+                await HandleClientDataFailureAsync(storeResult.FailureResult, cancellationToken);
                 await _localStorageService.SetItemAsync(key, data, cancellationToken);
             }
         }
@@ -155,6 +163,7 @@ namespace Lantean.QBTMud.Services
 
             if (!storeResult.Succeeded)
             {
+                await HandleClientDataFailureAsync(storeResult.FailureResult, cancellationToken);
                 await _localStorageService.SetItemAsStringAsync(key, data, cancellationToken);
             }
         }
@@ -174,7 +183,16 @@ namespace Lantean.QBTMud.Services
             var removeResult = await _clientDataStorageAdapter.RemovePrefixedEntriesAsync([ToPrefixedKey(key)], cancellationToken);
             if (!removeResult.Succeeded)
             {
+                await HandleClientDataFailureAsync(removeResult.FailureResult, cancellationToken);
                 await _localStorageService.RemoveItemAsync(key, cancellationToken);
+            }
+        }
+
+        private async Task HandleClientDataFailureAsync(ApiResultBase? failureResult, CancellationToken cancellationToken)
+        {
+            if (failureResult is not null)
+            {
+                await _apiFeedbackWorkflow.HandleFailureAsync(failureResult, cancellationToken: cancellationToken);
             }
         }
 

--- a/src/Lantean.QBTMud/Services/StorageDiagnosticsService.cs
+++ b/src/Lantean.QBTMud/Services/StorageDiagnosticsService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Lantean.QBTMud.Interop;
 using Lantean.QBTMud.Models;
 using Microsoft.JSInterop;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Services
 {
@@ -15,6 +16,7 @@ namespace Lantean.QBTMud.Services
         private readonly IJSRuntime _jsRuntime;
         private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
         private readonly IWebApiCapabilityService _webApiCapabilityService;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StorageDiagnosticsService"/> class.
@@ -22,14 +24,17 @@ namespace Lantean.QBTMud.Services
         /// <param name="jsRuntime">The JavaScript runtime.</param>
         /// <param name="clientDataStorageAdapter">The ClientData storage adapter.</param>
         /// <param name="webApiCapabilityService">The Web API capability service.</param>
+        /// <param name="apiFeedbackWorkflow">The API feedback workflow.</param>
         public StorageDiagnosticsService(
             IJSRuntime jsRuntime,
             IClientDataStorageAdapter clientDataStorageAdapter,
-            IWebApiCapabilityService webApiCapabilityService)
+            IWebApiCapabilityService webApiCapabilityService,
+            IApiFeedbackWorkflow apiFeedbackWorkflow)
         {
             _jsRuntime = jsRuntime;
             _clientDataStorageAdapter = clientDataStorageAdapter;
             _webApiCapabilityService = webApiCapabilityService;
+            _apiFeedbackWorkflow = apiFeedbackWorkflow;
         }
 
         /// <inheritdoc />
@@ -76,6 +81,10 @@ namespace Lantean.QBTMud.Services
                             textValue?.Length ?? 0));
                     }
                 }
+                else
+                {
+                    await HandleClientDataFailureAsync(clientEntriesResult.FailureResult, cancellationToken);
+                }
             }
 
             return result
@@ -109,7 +118,11 @@ namespace Lantean.QBTMud.Services
                 return;
             }
 
-            await _clientDataStorageAdapter.RemovePrefixedEntriesAsync([prefixedKey], cancellationToken);
+            var removeResult = await _clientDataStorageAdapter.RemovePrefixedEntriesAsync([prefixedKey], cancellationToken);
+            if (!removeResult.Succeeded)
+            {
+                await HandleClientDataFailureAsync(removeResult.FailureResult, cancellationToken);
+            }
         }
 
         /// <inheritdoc />
@@ -136,11 +149,27 @@ namespace Lantean.QBTMud.Services
                         {
                             removedCount += clientEntriesResult.Entries.Count;
                         }
+                        else
+                        {
+                            await HandleClientDataFailureAsync(removeResult.FailureResult, cancellationToken);
+                        }
+                    }
+                    else if (!clientEntriesResult.Succeeded)
+                    {
+                        await HandleClientDataFailureAsync(clientEntriesResult.FailureResult, cancellationToken);
                     }
                 }
             }
 
             return removedCount;
+        }
+
+        private async Task HandleClientDataFailureAsync(ApiResultBase? failureResult, CancellationToken cancellationToken)
+        {
+            if (failureResult is not null)
+            {
+                await _apiFeedbackWorkflow.HandleFailureAsync(failureResult, cancellationToken: cancellationToken);
+            }
         }
 
         private static string BuildPreview(string? value)

--- a/src/Lantean.QBTMud/Services/StorageRoutingService.cs
+++ b/src/Lantean.QBTMud/Services/StorageRoutingService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Lantean.QBTMud.Interop;
 using Lantean.QBTMud.Models;
 using Microsoft.JSInterop;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Services
 {
@@ -16,6 +17,7 @@ namespace Lantean.QBTMud.Services
         private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IStorageCatalogService _storageCatalogService;
         private readonly IJSRuntime _jsRuntime;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
         private StorageRoutingSettings? _cachedSettings;
 
         /// <summary>
@@ -26,18 +28,21 @@ namespace Lantean.QBTMud.Services
         /// <param name="webApiCapabilityService">The Web API capability service.</param>
         /// <param name="storageCatalogService">The routed storage catalog.</param>
         /// <param name="jsRuntime">The JavaScript runtime.</param>
+        /// <param name="apiFeedbackWorkflow">The API feedback workflow.</param>
         public StorageRoutingService(
             ILocalStorageService localStorageService,
             IClientDataStorageAdapter clientDataStorageAdapter,
             IWebApiCapabilityService webApiCapabilityService,
             IStorageCatalogService storageCatalogService,
-            IJSRuntime jsRuntime)
+            IJSRuntime jsRuntime,
+            IApiFeedbackWorkflow apiFeedbackWorkflow)
         {
             _localStorageService = localStorageService;
             _clientDataStorageAdapter = clientDataStorageAdapter;
             _webApiCapabilityService = webApiCapabilityService;
             _storageCatalogService = storageCatalogService;
             _jsRuntime = jsRuntime;
+            _apiFeedbackWorkflow = apiFeedbackWorkflow;
         }
 
         /// <inheritdoc />
@@ -179,6 +184,7 @@ namespace Lantean.QBTMud.Services
             var clientEntriesResult = await _clientDataStorageAdapter.LoadPrefixedEntriesAsync(cancellationToken);
             if (!clientEntriesResult.Succeeded || clientEntriesResult.Entries is null)
             {
+                await HandleClientDataFailureAsync(clientEntriesResult.FailureResult, cancellationToken);
                 return false;
             }
 
@@ -236,6 +242,7 @@ namespace Lantean.QBTMud.Services
                     cancellationToken);
                 if (!storeResult.Succeeded)
                 {
+                    await HandleClientDataFailureAsync(storeResult.FailureResult, cancellationToken);
                     return false;
                 }
 
@@ -251,6 +258,7 @@ namespace Lantean.QBTMud.Services
                     var loadedResult = await _clientDataStorageAdapter.LoadPrefixedEntriesAsync([prefixedKey], cancellationToken);
                     if (!loadedResult.Succeeded || loadedResult.Entries is null)
                     {
+                        await HandleClientDataFailureAsync(loadedResult.FailureResult, cancellationToken);
                         return false;
                     }
 
@@ -274,10 +282,24 @@ namespace Lantean.QBTMud.Services
                 }
 
                 var removeResult = await _clientDataStorageAdapter.RemovePrefixedEntriesAsync([prefixedKey], cancellationToken);
-                return removeResult.Succeeded;
+                if (!removeResult.Succeeded)
+                {
+                    await HandleClientDataFailureAsync(removeResult.FailureResult, cancellationToken);
+                    return false;
+                }
+
+                return true;
             }
 
             return true;
+        }
+
+        private async Task HandleClientDataFailureAsync(ApiResultBase? failureResult, CancellationToken cancellationToken)
+        {
+            if (failureResult is not null)
+            {
+                await _apiFeedbackWorkflow.HandleFailureAsync(failureResult, cancellationToken: cancellationToken);
+            }
         }
 
         private async Task<IReadOnlyDictionary<string, string?>> GetLocalEntriesByPrefixAsync(string keyPrefix, CancellationToken cancellationToken)

--- a/test/Lantean.QBTMud.Test/Services/ClientDataLoadResultTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/ClientDataLoadResultTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using Lantean.QBTMud.Services;
+using QBittorrent.ApiClient;
+
+namespace Lantean.QBTMud.Test.Services
+{
+    public sealed class ClientDataLoadResultTests
+    {
+        [Fact]
+        public void GIVEN_Entries_WHEN_FromEntries_THEN_ShouldCreateSuccessfulResultWithoutFailureResult()
+        {
+            var entries = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                ["QbtMud.Key"] = JsonDocument.Parse("\"Value\"").RootElement.Clone()
+            };
+
+            var result = ClientDataLoadResult.FromEntries(entries);
+
+            result.Succeeded.Should().BeTrue();
+            result.Entries.Should().BeSameAs(entries);
+            result.FailureResult.Should().BeNull();
+        }
+
+        [Fact]
+        public void GIVEN_FailedApiResult_WHEN_FromFailure_THEN_ShouldCreateFailedResultWithFailureResult()
+        {
+            var apiResult = ApiResult.CreateFailure(CreateFailure());
+
+            var result = ClientDataLoadResult.FromFailure(apiResult);
+
+            result.Succeeded.Should().BeFalse();
+            result.Entries.Should().BeNull();
+            result.FailureResult.Should().BeSameAs(apiResult);
+        }
+
+        [Fact]
+        public void GIVEN_NullFailureResult_WHEN_FromFailure_THEN_ShouldThrowArgumentNullException()
+        {
+            Action action = () => ClientDataLoadResult.FromFailure(null!);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GIVEN_SuccessfulApiResult_WHEN_FromFailure_THEN_ShouldThrowArgumentException()
+        {
+            Action action = () => ClientDataLoadResult.FromFailure(ApiResult.CreateSuccess());
+
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void GIVEN_GenericFailure_WHEN_FailureRead_THEN_ShouldNotSetFailureResult()
+        {
+            var result = ClientDataLoadResult.Failure;
+
+            result.Succeeded.Should().BeFalse();
+            result.Entries.Should().BeNull();
+            result.FailureResult.Should().BeNull();
+        }
+
+        private static ApiFailure CreateFailure()
+        {
+            return new ApiFailure
+            {
+                Detail = "Detail",
+                IsTransient = true,
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                ResponseBody = "ResponseBody",
+                UserMessage = "UserMessage"
+            };
+        }
+    }
+}

--- a/test/Lantean.QBTMud.Test/Services/ClientDataStorageAdapterTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/ClientDataStorageAdapterTests.cs
@@ -9,14 +9,12 @@ namespace Lantean.QBTMud.Test.Services
     public sealed class ClientDataStorageAdapterTests
     {
         private readonly IApiClient _apiClient;
-        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
         private readonly ClientDataStorageAdapter _target;
 
         public ClientDataStorageAdapterTests()
         {
             _apiClient = Mock.Of<IApiClient>();
-            _apiFeedbackWorkflow = Mock.Of<IApiFeedbackWorkflow>();
-            _target = new ClientDataStorageAdapter(_apiClient, _apiFeedbackWorkflow);
+            _target = new ClientDataStorageAdapter(_apiClient);
         }
 
         [Fact]
@@ -102,23 +100,13 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.LoadClientDataAsync(It.IsAny<IEnumerable<string>?>(), It.IsAny<CancellationToken>()))
                 .ReturnsFailure<IApiClient, IReadOnlyDictionary<string, JsonElement>>(ApiFailureKind.ServerError, "Failure");
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.HandleFailureAsync(
-                    It.IsAny<ApiResult<IReadOnlyDictionary<string, JsonElement>>>(),
-                    It.IsAny<Func<string?, string>?>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
 
             var result = await _target.LoadPrefixedEntriesAsync(["QbtMud.Key"], TestContext.Current.CancellationToken);
 
             result.Succeeded.Should().BeFalse();
             result.Entries.Should().BeNull();
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.HandleFailureAsync(
-                It.IsAny<ApiResult<IReadOnlyDictionary<string, JsonElement>>>(),
-                It.IsAny<Func<string?, string>?>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().NotBeNull();
+            result.FailureResult!.IsFailure.Should().BeTrue();
         }
 
         [Fact]
@@ -127,23 +115,13 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.LoadClientDataAsync(It.IsAny<IEnumerable<string>?>(), It.IsAny<CancellationToken>()))
                 .ReturnsFailure<IApiClient, IReadOnlyDictionary<string, JsonElement>>(ApiFailureKind.ServerError, "Failure");
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.HandleFailureAsync(
-                    It.IsAny<ApiResult<IReadOnlyDictionary<string, JsonElement>>>(),
-                    It.IsAny<Func<string?, string>?>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
 
             var result = await _target.LoadPrefixedEntriesAsync(TestContext.Current.CancellationToken);
 
             result.Succeeded.Should().BeFalse();
             result.Entries.Should().BeNull();
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.HandleFailureAsync(
-                It.IsAny<ApiResult<IReadOnlyDictionary<string, JsonElement>>>(),
-                It.IsAny<Func<string?, string>?>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().NotBeNull();
+            result.FailureResult!.IsFailure.Should().BeTrue();
         }
 
         [Fact]
@@ -175,12 +153,6 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.StoreClientDataAsync(It.IsAny<IReadOnlyDictionary<string, JsonElement?>>(), It.IsAny<CancellationToken>()))
                 .ReturnsSuccess(Task.CompletedTask);
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.ProcessResultAsync(
-                    It.IsAny<ApiResult>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
 
             var result = await _target.StorePrefixedEntriesAsync(
                 new Dictionary<string, object?>(StringComparer.Ordinal)
@@ -196,10 +168,7 @@ namespace Lantean.QBTMud.Test.Services
                 .Verify(client => client.StoreClientDataAsync(
                     It.Is<IReadOnlyDictionary<string, JsonElement?>>(payload => MatchesStoredPayload(payload)),
                     It.IsAny<CancellationToken>()), Times.Once);
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.ProcessResultAsync(
-                It.IsAny<ApiResult>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().BeNull();
         }
 
         [Fact]
@@ -208,12 +177,6 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.StoreClientDataAsync(It.IsAny<IReadOnlyDictionary<string, JsonElement?>>(), It.IsAny<CancellationToken>()))
                 .ReturnsFailure(ApiFailureKind.ServerError, "Failure");
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.ProcessResultAsync(
-                    It.IsAny<ApiResult>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(false);
 
             var result = await _target.StorePrefixedEntriesAsync(
                 new Dictionary<string, object?>(StringComparer.Ordinal)
@@ -223,10 +186,8 @@ namespace Lantean.QBTMud.Test.Services
                 TestContext.Current.CancellationToken);
 
             result.Succeeded.Should().BeFalse();
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.ProcessResultAsync(
-                It.IsAny<ApiResult>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().NotBeNull();
+            result.FailureResult!.IsFailure.Should().BeTrue();
         }
 
         [Fact]
@@ -252,12 +213,6 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.DeleteClientDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsSuccess(Task.CompletedTask);
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.ProcessResultAsync(
-                    It.IsAny<ApiResult>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
 
             var result = await _target.RemovePrefixedEntriesAsync(["QbtMud.Key", " QbtMud.Key ", "Other"], TestContext.Current.CancellationToken);
 
@@ -267,10 +222,7 @@ namespace Lantean.QBTMud.Test.Services
                     p => p.Count() == 1
                         && p.Contains("QbtMud.Key")
                     ), It.IsAny<CancellationToken>()), Times.Once);
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.ProcessResultAsync(
-                It.IsAny<ApiResult>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().BeNull();
         }
 
         [Fact]
@@ -279,20 +231,12 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_apiClient)
                 .Setup(client => client.DeleteClientDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsFailure(ApiFailureKind.ServerError, "Failure");
-            Mock.Get(_apiFeedbackWorkflow)
-                .Setup(workflow => workflow.ProcessResultAsync(
-                    It.IsAny<ApiResult>(),
-                    It.IsAny<MudBlazor.Severity>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(false);
 
             var result = await _target.RemovePrefixedEntriesAsync(["QbtMud.Key"], TestContext.Current.CancellationToken);
 
             result.Succeeded.Should().BeFalse();
-            Mock.Get(_apiFeedbackWorkflow).Verify(workflow => workflow.ProcessResultAsync(
-                It.IsAny<ApiResult>(),
-                It.IsAny<MudBlazor.Severity>(),
-                It.IsAny<CancellationToken>()), Times.Once);
+            result.FailureResult.Should().NotBeNull();
+            result.FailureResult!.IsFailure.Should().BeTrue();
         }
 
         private static bool MatchesStoredPayload(IReadOnlyDictionary<string, JsonElement?> payload)

--- a/test/Lantean.QBTMud.Test/Services/ClientDataStorageResultTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/ClientDataStorageResultTests.cs
@@ -1,0 +1,67 @@
+using AwesomeAssertions;
+using Lantean.QBTMud.Services;
+using QBittorrent.ApiClient;
+
+namespace Lantean.QBTMud.Test.Services
+{
+    public sealed class ClientDataStorageResultTests
+    {
+        [Fact]
+        public void GIVEN_SuccessResult_WHEN_SuccessRead_THEN_ShouldNotSetFailureResult()
+        {
+            var result = ClientDataStorageResult.Success;
+
+            result.Succeeded.Should().BeTrue();
+            result.FailureResult.Should().BeNull();
+        }
+
+        [Fact]
+        public void GIVEN_FailedApiResult_WHEN_FromFailure_THEN_ShouldCreateFailedResultWithFailureResult()
+        {
+            var apiResult = ApiResult.CreateFailure(CreateFailure());
+
+            var result = ClientDataStorageResult.FromFailure(apiResult);
+
+            result.Succeeded.Should().BeFalse();
+            result.FailureResult.Should().BeSameAs(apiResult);
+        }
+
+        [Fact]
+        public void GIVEN_NullFailureResult_WHEN_FromFailure_THEN_ShouldThrowArgumentNullException()
+        {
+            Action action = () => ClientDataStorageResult.FromFailure(null!);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GIVEN_SuccessfulApiResult_WHEN_FromFailure_THEN_ShouldThrowArgumentException()
+        {
+            Action action = () => ClientDataStorageResult.FromFailure(ApiResult.CreateSuccess());
+
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void GIVEN_GenericFailure_WHEN_FailureRead_THEN_ShouldNotSetFailureResult()
+        {
+            var result = ClientDataStorageResult.Failure;
+
+            result.Succeeded.Should().BeFalse();
+            result.FailureResult.Should().BeNull();
+        }
+
+        private static ApiFailure CreateFailure()
+        {
+            return new ApiFailure
+            {
+                Detail = "Detail",
+                IsTransient = true,
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                ResponseBody = "ResponseBody",
+                UserMessage = "UserMessage"
+            };
+        }
+    }
+}

--- a/test/Lantean.QBTMud.Test/Services/SettingsStorageServiceTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/SettingsStorageServiceTests.cs
@@ -4,6 +4,8 @@ using Lantean.QBTMud.Models;
 using Lantean.QBTMud.Services;
 using Lantean.QBTMud.Test.Infrastructure;
 using Moq;
+using MudBlazor;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Test.Services
 {
@@ -13,6 +15,7 @@ namespace Lantean.QBTMud.Test.Services
         private readonly IStorageRoutingService _storageRoutingService;
         private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
         private readonly SettingsStorageService _target;
 
         public SettingsStorageServiceTests()
@@ -21,6 +24,7 @@ namespace Lantean.QBTMud.Test.Services
             _storageRoutingService = Mock.Of<IStorageRoutingService>();
             _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
             _clientDataStorageAdapter = Mock.Of<IClientDataStorageAdapter>();
+            _apiFeedbackWorkflow = Mock.Of<IApiFeedbackWorkflow>();
 
             Mock.Get(_storageRoutingService)
                 .Setup(service => service.ResolveEffectiveStorageType(It.IsAny<string>(), It.IsAny<StorageRoutingSettings>(), It.IsAny<bool>()))
@@ -33,12 +37,20 @@ namespace Lantean.QBTMud.Test.Services
 
                     return StorageType.LocalStorage;
                 });
+            Mock.Get(_apiFeedbackWorkflow)
+                .Setup(workflow => workflow.HandleFailureAsync(
+                    It.IsAny<ApiResultBase>(),
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             _target = new SettingsStorageService(
                 _localStorageService,
                 _storageRoutingService,
                 _webApiCapabilityService,
-                _clientDataStorageAdapter);
+                _clientDataStorageAdapter,
+                _apiFeedbackWorkflow);
         }
 
         [Fact]
@@ -109,6 +121,8 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataStoreFails_WHEN_SetItemAsString_THEN_ShouldFallbackToLocalStorage()
         {
+            var apiResult = CreateFailureResult();
+
             Mock.Get(_storageRoutingService)
                 .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new StorageRoutingSettings
@@ -120,12 +134,13 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             await _target.SetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", "en_GB", TestContext.Current.CancellationToken);
 
             var storedValue = await _localStorageService.GetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", TestContext.Current.CancellationToken);
             storedValue.Should().Be("en_GB");
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -153,6 +168,8 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataLoadFails_WHEN_GetItemAsync_THEN_ShouldFallbackToLocalStorage()
         {
+            var apiResult = CreateFailureResult();
+
             await _localStorageService.SetItemAsync("AppSettings.State.v1", new Dictionary<string, bool>(StringComparer.Ordinal)
             {
                 ["enabled"] = true
@@ -169,12 +186,13 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataLoadResult.Failure);
+                .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
 
             var result = await _target.GetItemAsync<Dictionary<string, bool>>("AppSettings.State.v1", TestContext.Current.CancellationToken);
 
             result.Should().NotBeNull();
             result!["enabled"].Should().BeTrue();
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -301,6 +319,8 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataRemoveFails_WHEN_RemoveItemAsync_THEN_ShouldFallbackToLocalStorageRemoval()
         {
+            var apiResult = CreateFailureResult();
+
             await _localStorageService.SetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", "en_GB", TestContext.Current.CancellationToken);
 
             Mock.Get(_storageRoutingService)
@@ -314,12 +334,13 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             await _target.RemoveItemAsync("WebUiLocalization.PreferredLocale.v1", TestContext.Current.CancellationToken);
 
             var storedValue = await _localStorageService.GetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", TestContext.Current.CancellationToken);
             storedValue.Should().BeNull();
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -376,6 +397,8 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataSetFails_WHEN_SetItemAsync_THEN_ShouldFallbackToLocalStorage()
         {
+            var apiResult = CreateFailureResult();
+
             Mock.Get(_storageRoutingService)
                 .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new StorageRoutingSettings
@@ -387,13 +410,14 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             await _target.SetItemAsync("AppSettings.State.v1", new { enabled = true }, TestContext.Current.CancellationToken);
 
             var result = await _localStorageService.GetItemAsync<Dictionary<string, bool>>("AppSettings.State.v1", TestContext.Current.CancellationToken);
             result.Should().NotBeNull();
             result!["enabled"].Should().BeTrue();
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -588,6 +612,27 @@ namespace Lantean.QBTMud.Test.Services
 
             var result = await _localStorageService.GetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", TestContext.Current.CancellationToken);
             result.Should().Be("en");
+        }
+
+        private void VerifyFailureHandled(ApiResultBase apiResult)
+        {
+            Mock.Get(_apiFeedbackWorkflow)
+                .Verify(workflow => workflow.HandleFailureAsync(
+                    apiResult,
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        private static ApiResult CreateFailureResult()
+        {
+            return ApiResult.CreateFailure(new ApiFailure
+            {
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                UserMessage = "Failure"
+            });
         }
     }
 }

--- a/test/Lantean.QBTMud.Test/Services/StorageDiagnosticsServiceTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/StorageDiagnosticsServiceTests.cs
@@ -6,6 +6,8 @@ using Lantean.QBTMud.Services;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Test.Services
 {
@@ -14,6 +16,7 @@ namespace Lantean.QBTMud.Test.Services
         private readonly Mock<IJSRuntime> _jsRuntime;
         private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
         private readonly IWebApiCapabilityService _webApiCapabilityService;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
         private readonly StorageDiagnosticsService _target;
 
         public StorageDiagnosticsServiceTests()
@@ -21,7 +24,20 @@ namespace Lantean.QBTMud.Test.Services
             _jsRuntime = new Mock<IJSRuntime>(MockBehavior.Strict);
             _clientDataStorageAdapter = Mock.Of<IClientDataStorageAdapter>();
             _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
-            _target = new StorageDiagnosticsService(_jsRuntime.Object, _clientDataStorageAdapter, _webApiCapabilityService);
+            _apiFeedbackWorkflow = Mock.Of<IApiFeedbackWorkflow>();
+            Mock.Get(_apiFeedbackWorkflow)
+                .Setup(workflow => workflow.HandleFailureAsync(
+                    It.IsAny<ApiResultBase>(),
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _target = new StorageDiagnosticsService(
+                _jsRuntime.Object,
+                _clientDataStorageAdapter,
+                _webApiCapabilityService,
+                _apiFeedbackWorkflow);
         }
 
         [Fact]
@@ -149,6 +165,8 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataLoadFails_WHEN_GetEntriesInvoked_THEN_ShouldReturnLocalOnly()
         {
+            var apiResult = CreateFailureResult();
+
             _jsRuntime
                 .Setup(runtime => runtime.InvokeAsync<BrowserStorageEntry[]?>(
                     "qbt.getLocalStorageEntriesByPrefix",
@@ -160,13 +178,31 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataLoadResult.Failure);
+                .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
 
             var result = await _target.GetEntriesAsync(TestContext.Current.CancellationToken);
 
             result.Should().ContainSingle();
             result[0].StorageType.Should().Be(StorageType.LocalStorage);
             result[0].DisplayKey.Should().Be("LocalOnly");
+            VerifyFailureHandled(apiResult);
+        }
+
+        [Fact]
+        public async Task GIVEN_ClientStorageTypeRemoveFails_WHEN_RemoveEntryInvoked_THEN_ShouldHandleFailure()
+        {
+            var apiResult = CreateFailureResult();
+
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+            Mock.Get(_clientDataStorageAdapter)
+                .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
+
+            await _target.RemoveEntryAsync(StorageType.ClientData, "QbtMud.Key", TestContext.Current.CancellationToken);
+
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -270,12 +306,14 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientStorageTypeLoadFails_WHEN_ClearEntriesInvoked_THEN_ShouldReturnZero()
         {
+            var apiResult = CreateFailureResult();
+
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataLoadResult.Failure);
+                .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
 
             var removed = await _target.ClearEntriesAsync(StorageType.ClientData, TestContext.Current.CancellationToken);
 
@@ -283,11 +321,14 @@ namespace Lantean.QBTMud.Test.Services
             Mock.Get(_clientDataStorageAdapter).Verify(
                 adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
                 Times.Never);
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
         public async Task GIVEN_ClientStorageTypeRemoveFails_WHEN_ClearEntriesInvoked_THEN_ShouldReturnZero()
         {
+            var apiResult = CreateFailureResult();
+
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
@@ -300,11 +341,12 @@ namespace Lantean.QBTMud.Test.Services
                     }));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             var removed = await _target.ClearEntriesAsync(StorageType.ClientData, TestContext.Current.CancellationToken);
 
             removed.Should().Be(0);
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -333,6 +375,27 @@ namespace Lantean.QBTMud.Test.Services
             result.Single(entry => entry.DisplayKey == "Local").Preview.Should().BeEmpty();
             result.Single(entry => entry.DisplayKey == "Null").Value.Should().BeNull();
             result.Single(entry => entry.DisplayKey == "String").Value.Should().Be("text");
+        }
+
+        private void VerifyFailureHandled(ApiResultBase apiResult)
+        {
+            Mock.Get(_apiFeedbackWorkflow)
+                .Verify(workflow => workflow.HandleFailureAsync(
+                    apiResult,
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        private static ApiResult CreateFailureResult()
+        {
+            return ApiResult.CreateFailure(new ApiFailure
+            {
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                UserMessage = "Failure"
+            });
         }
     }
 }

--- a/test/Lantean.QBTMud.Test/Services/StorageRoutingServiceTests.cs
+++ b/test/Lantean.QBTMud.Test/Services/StorageRoutingServiceTests.cs
@@ -6,6 +6,8 @@ using Lantean.QBTMud.Services;
 using Lantean.QBTMud.Test.Infrastructure;
 using Microsoft.JSInterop;
 using Moq;
+using MudBlazor;
+using QBittorrent.ApiClient;
 
 namespace Lantean.QBTMud.Test.Services
 {
@@ -16,6 +18,7 @@ namespace Lantean.QBTMud.Test.Services
         private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IStorageCatalogService _storageCatalogService;
         private readonly Mock<IJSRuntime> _jsRuntime;
+        private readonly IApiFeedbackWorkflow _apiFeedbackWorkflow;
         private readonly StorageRoutingService _target;
 
         public StorageRoutingServiceTests()
@@ -24,6 +27,7 @@ namespace Lantean.QBTMud.Test.Services
             _clientDataStorageAdapter = Mock.Of<IClientDataStorageAdapter>();
             _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
             _storageCatalogService = new StorageCatalogService();
+            _apiFeedbackWorkflow = Mock.Of<IApiFeedbackWorkflow>();
             _jsRuntime = new Mock<IJSRuntime>(MockBehavior.Strict);
             _jsRuntime
                 .Setup(runtime => runtime.InvokeAsync<BrowserStorageEntry[]?>(
@@ -31,13 +35,21 @@ namespace Lantean.QBTMud.Test.Services
                     It.IsAny<CancellationToken>(),
                     It.IsAny<object?[]?>()))
                 .ReturnsAsync(Array.Empty<BrowserStorageEntry>());
+            Mock.Get(_apiFeedbackWorkflow)
+                .Setup(workflow => workflow.HandleFailureAsync(
+                    It.IsAny<ApiResultBase>(),
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             _target = new StorageRoutingService(
                 _localStorageService,
                 _clientDataStorageAdapter,
                 _webApiCapabilityService,
                 _storageCatalogService,
-                _jsRuntime.Object);
+                _jsRuntime.Object,
+                _apiFeedbackWorkflow);
         }
 
         [Fact]
@@ -562,6 +574,7 @@ namespace Lantean.QBTMud.Test.Services
             var localStorageService = new TestLocalStorageService();
             var clientDataStorageAdapter = new Mock<IClientDataStorageAdapter>(MockBehavior.Strict);
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
+            var apiFeedbackWorkflow = new Mock<IApiFeedbackWorkflow>(MockBehavior.Strict);
 
             await localStorageService.SetItemAsStringAsync("QbtMud.Custom.Key", "value", TestContext.Current.CancellationToken);
 
@@ -580,7 +593,8 @@ namespace Lantean.QBTMud.Test.Services
                 clientDataStorageAdapter.Object,
                 webApiCapabilityService.Object,
                 customCatalogService.Object,
-                jsRuntime.Object);
+                jsRuntime.Object,
+                apiFeedbackWorkflow.Object);
 
             await customTarget.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -656,12 +670,14 @@ namespace Lantean.QBTMud.Test.Services
         [Fact]
         public async Task GIVEN_ClientDataStoreFails_WHEN_SavingClientDataRouting_THEN_ShouldThrowInvalidOperationException()
         {
+            var apiResult = CreateFailureResult();
+
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             await _localStorageService.SetItemAsStringAsync("AppSettings.State.v1", "{\"theme\":\"dark\"}", TestContext.Current.CancellationToken);
 
@@ -678,11 +694,14 @@ namespace Lantean.QBTMud.Test.Services
 
             var persisted = await _localStorageService.GetItemAsync<StorageRoutingSettings>(StorageRoutingSettings.StorageKey, TestContext.Current.CancellationToken);
             persisted.Should().BeNull();
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
         public async Task GIVEN_ClientDataLoadFails_WHEN_SavingLocalStorageRouting_THEN_ShouldThrowInvalidOperationException()
         {
+            var apiResult = CreateFailureResult();
+
             await _localStorageService.SetItemAsync(StorageRoutingSettings.StorageKey, new StorageRoutingSettings
             {
                 MasterStorageType = StorageType.ClientData
@@ -692,7 +711,7 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataLoadResult.Failure);
+                .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
 
             var act = async () => await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -705,11 +724,14 @@ namespace Lantean.QBTMud.Test.Services
             var persisted = await _localStorageService.GetItemAsync<StorageRoutingSettings>(StorageRoutingSettings.StorageKey, TestContext.Current.CancellationToken);
             persisted.Should().NotBeNull();
             persisted!.MasterStorageType.Should().Be(StorageType.ClientData);
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
         public async Task GIVEN_ClientDataRemoveFails_WHEN_SavingLocalStorageRouting_THEN_ShouldThrowInvalidOperationException()
         {
+            var apiResult = CreateFailureResult();
+
             await _localStorageService.SetItemAsync(StorageRoutingSettings.StorageKey, new StorageRoutingSettings
             {
                 MasterStorageType = StorageType.ClientData
@@ -728,7 +750,7 @@ namespace Lantean.QBTMud.Test.Services
                 .ReturnsAsync(Loaded(new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ClientDataStorageResult.Failure);
+                .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
 
             var act = async () => await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -744,6 +766,7 @@ namespace Lantean.QBTMud.Test.Services
             var persisted = await _localStorageService.GetItemAsync<StorageRoutingSettings>(StorageRoutingSettings.StorageKey, TestContext.Current.CancellationToken);
             persisted.Should().NotBeNull();
             persisted!.MasterStorageType.Should().Be(StorageType.ClientData);
+            VerifyFailureHandled(apiResult);
         }
 
         [Fact]
@@ -754,6 +777,7 @@ namespace Lantean.QBTMud.Test.Services
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             var storageCatalogService = new StorageCatalogService();
             var jsRuntime = new Mock<IJSRuntime>(MockBehavior.Strict);
+            var apiFeedbackWorkflow = new Mock<IApiFeedbackWorkflow>(MockBehavior.Strict);
 
             var readCompletion = new TaskCompletionSource<StorageRoutingSettings?>(TaskCreationOptions.RunContinuationsAsynchronously);
             localStorageService
@@ -765,7 +789,8 @@ namespace Lantean.QBTMud.Test.Services
                 clientDataStorageAdapter.Object,
                 webApiCapabilityService.Object,
                 storageCatalogService,
-                jsRuntime.Object);
+                jsRuntime.Object,
+                apiFeedbackWorkflow.Object);
 
             var firstTask = target.GetSettingsAsync(TestContext.Current.CancellationToken);
             var secondTask = target.GetSettingsAsync(TestContext.Current.CancellationToken);
@@ -785,6 +810,27 @@ namespace Lantean.QBTMud.Test.Services
         private static ClientDataLoadResult Loaded(IReadOnlyDictionary<string, JsonElement> entries)
         {
             return ClientDataLoadResult.FromEntries(entries);
+        }
+
+        private void VerifyFailureHandled(ApiResultBase apiResult)
+        {
+            Mock.Get(_apiFeedbackWorkflow)
+                .Verify(workflow => workflow.HandleFailureAsync(
+                    apiResult,
+                    It.IsAny<Func<string?, string>?>(),
+                    It.IsAny<Severity>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        private static ApiResult CreateFailureResult()
+        {
+            return ApiResult.CreateFailure(new ApiFailure
+            {
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                UserMessage = "Failure"
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary

Decouples ClientData storage operations from API feedback handling while preserving user-facing failure feedback at the service call sites.

## What Changed

- Removed `IApiFeedbackWorkflow` responsibility from `ClientDataStorageAdapter`.
- Added `FailureResult` support to ClientData load/storage results.
- Forwarded ClientData API failures from settings, routing, and diagnostics services.
- Added tests for failure result enforcement and feedback handoff behaviour.

## Testing

- Added unit tests

## Notes

- ClientData adapter now only translates API results; callers decide recovery and feedback behaviour.
