### PR TITLE
Theme Manager Updates and Preview

### DIFF
--- a/src/Lantean.QBTMud.Application/Services/IThemeManagerService.cs
+++ b/src/Lantean.QBTMud.Application/Services/IThemeManagerService.cs
@@ -43,6 +43,12 @@ namespace Lantean.QBTMud.Application.Services
         ThemeModePreference CurrentThemeModePreference { get; }
 
         /// <summary>
+        /// Resolves the effective storage type currently used for custom themes.
+        /// </summary>
+        /// <returns>The effective storage type for custom themes.</returns>
+        Task<StorageType> GetLocalThemeStorageTypeAsync();
+
+        /// <summary>
         /// Gets a value indicating whether the most recent theme-source reload had repository issues.
         /// </summary>
         bool LastReloadHadRepositoryIssues { get; }

--- a/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogItem.cs
+++ b/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogItem.cs
@@ -1,0 +1,45 @@
+using MudBlazor;
+
+namespace Lantean.QBTMud.Core.Models
+{
+    /// <summary>
+    /// Represents a theme that can be browsed in the preview dialog.
+    /// </summary>
+    public sealed class ThemePreviewDialogItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThemePreviewDialogItem"/> class.
+        /// </summary>
+        /// <param name="themeId">The theme identifier.</param>
+        /// <param name="name">The display name.</param>
+        /// <param name="sourceLabel">The display source label.</param>
+        /// <param name="theme">The theme to preview.</param>
+        public ThemePreviewDialogItem(string themeId, string name, string sourceLabel, MudTheme theme)
+        {
+            ThemeId = themeId;
+            Name = name;
+            SourceLabel = sourceLabel;
+            Theme = theme;
+        }
+
+        /// <summary>
+        /// Gets the theme identifier.
+        /// </summary>
+        public string ThemeId { get; }
+
+        /// <summary>
+        /// Gets the display name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the display source label.
+        /// </summary>
+        public string SourceLabel { get; }
+
+        /// <summary>
+        /// Gets the theme to preview.
+        /// </summary>
+        public MudTheme Theme { get; }
+    }
+}

--- a/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogMode.cs
+++ b/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogMode.cs
@@ -1,0 +1,11 @@
+namespace Lantean.QBTMud.Core.Models
+{
+    /// <summary>
+    /// Specifies how the theme preview dialog should behave.
+    /// </summary>
+    public enum ThemePreviewDialogMode
+    {
+        Catalogue,
+        Details
+    }
+}

--- a/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogRequest.cs
+++ b/src/Lantean.QBTMud.Core/Models/ThemePreviewDialogRequest.cs
@@ -1,0 +1,69 @@
+using MudBlazor;
+
+namespace Lantean.QBTMud.Core.Models
+{
+    /// <summary>
+    /// Represents the input for the theme preview dialog.
+    /// </summary>
+    public sealed class ThemePreviewDialogRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThemePreviewDialogRequest"/> class.
+        /// </summary>
+        /// <param name="items">The themes available for preview.</param>
+        /// <param name="selectedThemeId">The initially selected theme identifier.</param>
+        /// <param name="mode">The preview mode.</param>
+        /// <param name="isDarkMode">Whether the preview starts in dark mode.</param>
+        public ThemePreviewDialogRequest(
+            IReadOnlyList<ThemePreviewDialogItem> items,
+            string selectedThemeId,
+            ThemePreviewDialogMode mode,
+            bool isDarkMode)
+        {
+            Items = items;
+            SelectedThemeId = selectedThemeId;
+            Mode = mode;
+            IsDarkMode = isDarkMode;
+        }
+
+        /// <summary>
+        /// Gets the themes available for preview.
+        /// </summary>
+        public IReadOnlyList<ThemePreviewDialogItem> Items { get; }
+
+        /// <summary>
+        /// Gets the initially selected theme identifier.
+        /// </summary>
+        public string SelectedThemeId { get; }
+
+        /// <summary>
+        /// Gets the preview mode.
+        /// </summary>
+        public ThemePreviewDialogMode Mode { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the preview starts in dark mode.
+        /// </summary>
+        public bool IsDarkMode { get; }
+
+        /// <summary>
+        /// Gets or sets the currently applied persisted theme identifier.
+        /// </summary>
+        public string? CurrentThemeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the details-mode save-and-apply action is enabled.
+        /// </summary>
+        public bool CanSaveAndApply { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback used to apply a persisted previewed theme.
+        /// </summary>
+        public Func<string, Task<bool>>? ApplyThemeAsync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback used to save and apply the details preview theme.
+        /// </summary>
+        public Func<Task<bool>>? SaveAndApplyThemeAsync { get; set; }
+    }
+}

--- a/src/Lantean.QBTMud.Infrastructure/Services/ThemeManagerService.cs
+++ b/src/Lantean.QBTMud.Infrastructure/Services/ThemeManagerService.cs
@@ -24,6 +24,8 @@ namespace Lantean.QBTMud.Infrastructure.Services
         private readonly Lock _repositoryLoadLock = new();
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ISettingsStorageService _settingsStorage;
+        private readonly IStorageRoutingService _storageRoutingService;
+        private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IThemeFontCatalog _themeFontCatalog;
         private readonly ILanguageLocalizer _languageLocalizer;
         private readonly IAppSettingsService _appSettingsService;
@@ -47,6 +49,8 @@ namespace Lantean.QBTMud.Infrastructure.Services
         /// </summary>
         /// <param name="httpClientFactory">The HTTP client factory for loading theme assets.</param>
         /// <param name="settingsStorage">The local storage service.</param>
+        /// <param name="storageRoutingService">The storage routing service.</param>
+        /// <param name="webApiCapabilityService">The Web API capability service.</param>
         /// <param name="themeFontCatalog">The theme font catalog.</param>
         /// <param name="languageLocalizer">The language localizer.</param>
         /// <param name="appSettingsService">The app settings service.</param>
@@ -54,6 +58,8 @@ namespace Lantean.QBTMud.Infrastructure.Services
         public ThemeManagerService(
             IHttpClientFactory httpClientFactory,
             ISettingsStorageService settingsStorage,
+            IStorageRoutingService storageRoutingService,
+            IWebApiCapabilityService webApiCapabilityService,
             IThemeFontCatalog themeFontCatalog,
             ILanguageLocalizer languageLocalizer,
             IAppSettingsService appSettingsService,
@@ -61,6 +67,8 @@ namespace Lantean.QBTMud.Infrastructure.Services
         {
             _httpClientFactory = httpClientFactory;
             _settingsStorage = settingsStorage;
+            _storageRoutingService = storageRoutingService;
+            _webApiCapabilityService = webApiCapabilityService;
             _themeFontCatalog = themeFontCatalog;
             _languageLocalizer = languageLocalizer;
             _appSettingsService = appSettingsService;
@@ -115,6 +123,17 @@ namespace Lantean.QBTMud.Infrastructure.Services
         public ThemeModePreference CurrentThemeModePreference
         {
             get { return _currentThemeModePreference; }
+        }
+
+        /// <summary>
+        /// Resolves the effective storage type currently used for custom themes.
+        /// </summary>
+        /// <returns>The effective storage type for custom themes.</returns>
+        public async Task<StorageType> GetLocalThemeStorageTypeAsync()
+        {
+            var settings = await _storageRoutingService.GetSettingsAsync();
+            var capabilityState = await _webApiCapabilityService.GetCapabilityStateAsync();
+            return _storageRoutingService.ResolveEffectiveStorageType(_localThemesStorageKey, settings, capabilityState.SupportsClientData);
         }
 
         /// <summary>

--- a/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor
+++ b/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor
@@ -1,8 +1,8 @@
 @using Lantean.QBTMud.Components.UI
 @using Lantean.QBTMud.Helpers
 @using MudBlazor.Utilities
-<MudDialog ContentClass="theme-preview-dialog__content"
-           Style="width: min(1800px, calc(100vw - 4rem)); height: calc(100vh - 4rem);">
+<MudDialog Class="theme-preview-dialog"
+           ContentClass="theme-preview-dialog__content">
     <DialogContent>
         <MudThemeProvider Theme="PreviewTheme"
                           IsDarkMode="@_isDarkMode"
@@ -12,13 +12,7 @@
                 <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" data-test-id="@TestIdHelper.For("ThemePreviewMenu")" />
                 <MudText Typo="Typo.subtitle1">@Translate("qBittorrent Web UI")</MudText>
                 <MudSpacer />
-                <MudIconButton Icon="@DarkModeIcon"
-                               Color="Color.Inherit"
-                               title="@DarkModeTooltip"
-                               OnClick="ToggleDarkMode"
-                               data-test-id="@TestIdHelper.For("ThemePreviewToggleMode")" />
                 <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" data-test-id="@TestIdHelper.For("ThemePreviewOptions")" />
-                <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" OnClick="Close" data-test-id="@TestIdHelper.For("ThemePreviewClose")" />
             </div>
             <div class="theme-preview__body">
                 <div class="theme-preview__sidebar">
@@ -87,4 +81,61 @@
             </div>
         </div>
     </DialogContent>
+    <DialogActions>
+        <div style="display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; width: 100%;">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="justify-self: start;">
+                <MudIconButton Icon="@DarkModeIcon"
+                               title="@DarkModeTooltip"
+                               OnClick="ToggleDarkMode"
+                               data-test-id="@TestIdHelper.For("ThemePreviewToggleMode")" />
+            </MudStack>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.Center" Spacing="1" Style="justify-self: center;">
+                @if (IsCatalogueMode)
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore"
+                                   title="@Translate("Previous theme")"
+                                   OnClick="ShowPreviousTheme"
+                                   Disabled="@(!CanGoPrevious)"
+                                   data-test-id="@TestIdHelper.For("ThemePreviewPrevious")" />
+                }
+                <MudText Typo="Typo.subtitle2" data-test-id="@TestIdHelper.For("ThemePreviewName")">@CurrentItem.Name</MudText>
+                @if (IsCatalogueMode)
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.NavigateNext"
+                                   title="@Translate("Next theme")"
+                                   OnClick="ShowNextTheme"
+                                   Disabled="@(!CanGoNext)"
+                                   data-test-id="@TestIdHelper.For("ThemePreviewNext")" />
+                }
+            </MudStack>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="justify-self: end;">
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Default"
+                           OnClick="Close"
+                           data-test-id="@TestIdHelper.For("ThemePreviewCancel")">
+                    @Translate("Cancel")
+                </MudButton>
+                @if (IsCatalogueMode && Request.ApplyThemeAsync is not null)
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Success"
+                               OnClick="ApplyCurrentTheme"
+                               Disabled="@(!CanApplyCurrentTheme)"
+                               data-test-id="@TestIdHelper.For("ThemePreviewApply")">
+                        @Translate("Apply")
+                    </MudButton>
+                }
+                @if (!IsCatalogueMode && Request.SaveAndApplyThemeAsync is not null)
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Success"
+                               OnClick="SaveAndApplyCurrentTheme"
+                               Disabled="@(!CanSaveAndApply)"
+                               data-test-id="@TestIdHelper.For("ThemePreviewSaveApply")">
+                        @Translate("Save & apply")
+                    </MudButton>
+                }
+            </MudStack>
+        </div>
+    </DialogActions>
 </MudDialog>

--- a/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor.cs
@@ -1,4 +1,6 @@
+using Lantean.QBTMud.Application.Services;
 using Lantean.QBTMud.Application.Services.Localization;
+using Lantean.QBTMud.Core.Models;
 using Lantean.QBTMud.Core.Theming;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -6,13 +8,18 @@ using MudBlazor;
 
 namespace Lantean.QBTMud.Components.Dialogs
 {
-    public partial class ThemePreviewDialog
+    public partial class ThemePreviewDialog : IAsyncDisposable
     {
         private const string _previewScope = "root .theme-preview-scope";
+        private static readonly KeyboardEvent _arrowLeftKey = new("ArrowLeft");
+        private static readonly KeyboardEvent _arrowRightKey = new("ArrowRight");
 
         private MudTheme _previewTheme = new();
+        private int _selectedIndex;
         private bool _isDarkMode;
         private bool _initialized;
+        private bool _shortcutsRegistered;
+        private bool _disposedValue;
 
         [CascadingParameter]
         protected IMudDialogInstance MudDialog { get; set; } = default!;
@@ -21,26 +28,75 @@ namespace Lantean.QBTMud.Components.Dialogs
         protected ILanguageLocalizer LanguageLocalizer { get; set; } = default!;
 
         [Parameter]
-        public MudTheme? Theme { get; set; }
+        public ThemePreviewDialogRequest Request { get; set; } = default!;
 
-        [Parameter]
-        public bool IsDarkMode { get; set; }
+        [Inject]
+        protected IKeyboardService KeyboardService { get; set; } = default!;
 
         protected MudTheme PreviewTheme
         {
             get { return _previewTheme; }
         }
 
+        protected ThemePreviewDialogItem CurrentItem
+        {
+            get { return Request.Items[_selectedIndex]; }
+        }
+
+        protected bool IsCatalogueMode
+        {
+            get { return Request.Mode == ThemePreviewDialogMode.Catalogue; }
+        }
+
+        protected bool CanGoPrevious
+        {
+            get { return IsCatalogueMode && _selectedIndex > 0; }
+        }
+
+        protected bool CanGoNext
+        {
+            get { return IsCatalogueMode && _selectedIndex < Request.Items.Count - 1; }
+        }
+
+        protected bool CanApplyCurrentTheme
+        {
+            get
+            {
+                return IsCatalogueMode
+                    && Request.ApplyThemeAsync is not null
+                    && !string.Equals(CurrentItem.ThemeId, Request.CurrentThemeId, StringComparison.Ordinal);
+            }
+        }
+
+        protected bool CanSaveAndApply
+        {
+            get { return !IsCatalogueMode && Request.SaveAndApplyThemeAsync is not null && Request.CanSaveAndApply; }
+        }
+
         protected override void OnParametersSet()
         {
             if (!_initialized)
             {
-                _isDarkMode = IsDarkMode;
+                ArgumentNullException.ThrowIfNull(Request);
+
+                _selectedIndex = FindSelectedIndex();
+                _isDarkMode = Request.IsDarkMode;
                 _initialized = true;
             }
 
-            _previewTheme = BuildPreviewTheme(Theme);
+            _previewTheme = BuildPreviewTheme(CurrentItem.Theme);
             _previewTheme.PseudoCss.Scope = _previewScope;
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                await KeyboardService.RegisterKeypressEvent(_arrowLeftKey, HandleArrowLeftAsync);
+                await KeyboardService.RegisterKeypressEvent(_arrowRightKey, HandleArrowRightAsync);
+                await KeyboardService.Focus();
+                _shortcutsRegistered = true;
+            }
         }
 
         protected string DarkModeIcon
@@ -63,9 +119,88 @@ namespace Lantean.QBTMud.Components.Dialogs
             _isDarkMode = !_isDarkMode;
         }
 
+        protected Task ShowPreviousTheme()
+        {
+            if (!CanGoPrevious)
+            {
+                return Task.CompletedTask;
+            }
+
+            _selectedIndex--;
+            _previewTheme = BuildPreviewTheme(CurrentItem.Theme);
+            _previewTheme.PseudoCss.Scope = _previewScope;
+            return InvokeAsync(StateHasChanged);
+        }
+
+        protected Task ShowNextTheme()
+        {
+            if (!CanGoNext)
+            {
+                return Task.CompletedTask;
+            }
+
+            _selectedIndex++;
+            _previewTheme = BuildPreviewTheme(CurrentItem.Theme);
+            _previewTheme.PseudoCss.Scope = _previewScope;
+            return InvokeAsync(StateHasChanged);
+        }
+
+        protected async Task ApplyCurrentTheme()
+        {
+            if (!CanApplyCurrentTheme)
+            {
+                return;
+            }
+
+            var applied = await Request.ApplyThemeAsync!(CurrentItem.ThemeId);
+            if (applied)
+            {
+                MudDialog.Close();
+            }
+        }
+
+        protected async Task SaveAndApplyCurrentTheme()
+        {
+            if (!CanSaveAndApply)
+            {
+                return;
+            }
+
+            var applied = await Request.SaveAndApplyThemeAsync!();
+            if (applied)
+            {
+                MudDialog.Close();
+            }
+        }
+
         private Task HandleNavClick(MouseEventArgs args)
         {
             return Task.CompletedTask;
+        }
+
+        private Task HandleArrowLeftAsync(KeyboardEvent keyboardEvent)
+        {
+            return ShowPreviousTheme();
+        }
+
+        private Task HandleArrowRightAsync(KeyboardEvent keyboardEvent)
+        {
+            return ShowNextTheme();
+        }
+
+        private int FindSelectedIndex()
+        {
+            if (Request.Items.Count == 0)
+            {
+                throw new InvalidOperationException("The theme preview dialog requires at least one preview item.");
+            }
+
+            var selectedIndex = Request.Items
+                .Select((item, index) => new { item.ThemeId, index })
+                .FirstOrDefault(entry => string.Equals(entry.ThemeId, Request.SelectedThemeId, StringComparison.Ordinal))
+                ?.index;
+
+            return selectedIndex ?? 0;
         }
 
         private static MudTheme BuildPreviewTheme(MudTheme? theme)
@@ -76,6 +211,25 @@ namespace Lantean.QBTMud.Components.Dialogs
         private string Translate(string value)
         {
             return LanguageLocalizer.Translate("AppThemePreviewDialog", value);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposedValue)
+            {
+                return;
+            }
+
+            if (_shortcutsRegistered)
+            {
+                await KeyboardService.UnregisterKeypressEvent(_arrowLeftKey);
+                await KeyboardService.UnregisterKeypressEvent(_arrowRightKey);
+                await KeyboardService.UnFocus();
+                _shortcutsRegistered = false;
+            }
+
+            _disposedValue = true;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor.css
+++ b/src/Lantean.QBTMud.Presentation/Components/Dialogs/ThemePreviewDialog.razor.css
@@ -3,6 +3,13 @@
     height: 100%;
 }
 
+.theme-preview-dialog {
+    overflow: hidden;
+    width: min(1800px, calc(100vw - 4rem));
+    height: calc(100vh - 4rem);
+    max-width: none;
+}
+
 .theme-preview {
     height: 100%;
     display: flex;
@@ -62,5 +69,25 @@
 @media (max-width: 900px) {
     .theme-preview__sidebar {
         display: none;
+    }
+}
+
+@media (max-width: 900px) {
+    .theme-preview-dialog {
+        width: calc(100vw - 1rem);
+        height: calc(100vh - 1rem);
+    }
+
+    .theme-preview-dialog ::deep .mud-dialog {
+        margin: 0.5rem;
+        border-radius: 12px;
+    }
+
+    .theme-preview__content {
+        padding: 0.875rem;
+    }
+
+    .theme-preview__footer {
+        padding-inline: 0.5rem;
     }
 }

--- a/src/Lantean.QBTMud.Presentation/Helpers/ThemeActionHelper.cs
+++ b/src/Lantean.QBTMud.Presentation/Helpers/ThemeActionHelper.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using Lantean.QBTMud.Core.Interop;
+using Lantean.QBTMud.Core.Models;
+using Lantean.QBTMud.Core.Theming;
+using Lantean.QBTMud.Services;
+using Microsoft.JSInterop;
+
+namespace Lantean.QBTMud.Helpers
+{
+    internal static class ThemeActionHelper
+    {
+        public static async Task<ThemeDefinition?> DuplicateThemeAsync(ThemeCatalogItem theme, IDialogWorkflow dialogWorkflow, Func<string, object[], string> translate)
+        {
+            ArgumentNullException.ThrowIfNull(theme);
+            ArgumentNullException.ThrowIfNull(dialogWorkflow);
+            ArgumentNullException.ThrowIfNull(translate);
+
+            var defaultName = translate("%1 Copy", [theme.Name]);
+            var name = await dialogWorkflow.ShowStringFieldDialog(translate("Duplicate Theme", []), translate("Name", []), defaultName);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return null;
+            }
+
+            var clone = ThemeSerialization.CloneDefinition(theme.Theme);
+            clone.Id = Guid.NewGuid().ToString("N");
+            clone.Name = name.Trim();
+            return clone;
+        }
+
+        public static async Task ExportThemeAsync(ThemeCatalogItem theme, IJSRuntime jsRuntime, Func<string, object[], string> translate)
+        {
+            ArgumentNullException.ThrowIfNull(theme);
+            ArgumentNullException.ThrowIfNull(jsRuntime);
+            ArgumentNullException.ThrowIfNull(translate);
+
+            var definition = ThemeSerialization.CloneDefinition(theme.Theme);
+            definition.Id = theme.Id;
+            definition.Name = theme.Name;
+
+            var json = ThemeSerialization.SerializeDefinition(definition, writeIndented: true);
+            var safeName = SanitizeFileName(theme.Name, translate);
+            var dataUrl = BuildJsonDataUrl(json);
+
+            await jsRuntime.FileDownload(dataUrl, $"{safeName}.json");
+        }
+
+        private static string SanitizeFileName(string name, Func<string, object[], string> translate)
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var builder = new StringBuilder(name.Length);
+
+            foreach (var ch in name)
+            {
+                builder.Append(invalidChars.Contains(ch) ? '-' : ch);
+            }
+
+            var sanitized = builder.ToString().Trim();
+            if (string.IsNullOrWhiteSpace(sanitized))
+            {
+                return translate("theme", []);
+            }
+
+            return sanitized;
+        }
+
+        private static string BuildJsonDataUrl(string json)
+        {
+            var escaped = Uri.EscapeDataString(json);
+            return $"data:application/json;charset=utf-8,{escaped}";
+        }
+    }
+}

--- a/src/Lantean.QBTMud.Presentation/Helpers/ThemeDisplayHelper.cs
+++ b/src/Lantean.QBTMud.Presentation/Helpers/ThemeDisplayHelper.cs
@@ -1,0 +1,52 @@
+using Lantean.QBTMud.Core.Models;
+using Lantean.QBTMud.Core.Theming;
+using MudBlazor;
+
+namespace Lantean.QBTMud.Helpers
+{
+    internal static class ThemeDisplayHelper
+    {
+        public static string GetSourceLabel(ThemeCatalogItem theme, StorageType localThemeStorageType, Func<string, string> translate)
+        {
+            ArgumentNullException.ThrowIfNull(theme);
+            ArgumentNullException.ThrowIfNull(translate);
+
+            return theme.Source switch
+            {
+                ThemeSource.Local when localThemeStorageType == StorageType.ClientData => translate("Client Data"),
+                ThemeSource.Local => translate("Local Storage"),
+                ThemeSource.Repository => translate("Repository"),
+                _ => translate("Bundled")
+            };
+        }
+
+        public static Color GetSourceChipColor(ThemeCatalogItem theme)
+        {
+            ArgumentNullException.ThrowIfNull(theme);
+
+            return theme.Source switch
+            {
+                ThemeSource.Local => Color.Default,
+                ThemeSource.Repository => Color.Secondary,
+                _ => Color.Info
+            };
+        }
+
+        public static IReadOnlyList<ThemePreviewDialogItem> CreatePreviewItems(
+            IEnumerable<ThemeCatalogItem> themes,
+            StorageType localThemeStorageType,
+            Func<string, string> translate)
+        {
+            ArgumentNullException.ThrowIfNull(themes);
+            ArgumentNullException.ThrowIfNull(translate);
+
+            return themes
+                .Select(theme => new ThemePreviewDialogItem(
+                    theme.Id,
+                    theme.Name,
+                    GetSourceLabel(theme, localThemeStorageType, translate),
+                    ThemeSerialization.CloneTheme(theme.Theme.Theme)))
+                .ToList();
+        }
+    }
+}

--- a/src/Lantean.QBTMud.Presentation/Pages/ThemeDetail.razor
+++ b/src/Lantean.QBTMud.Presentation/Pages/ThemeDetail.razor
@@ -15,6 +15,27 @@
                                OnClick="ShowPreview"
                                Disabled="@IsBusy"
                                data-test-id="@TestIdHelper.For("ThemeDetailPreview")" />
+                <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                               title="@Translate("Rename")"
+                               OnClick="RenameTheme"
+                               Disabled="@(!CanEditTheme || HasChanges || IsBusy)"
+                               data-test-id="@TestIdHelper.For("ThemeDetailRename")" />
+                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
+                               title="@Translate("Duplicate")"
+                               OnClick="DuplicateTheme"
+                               Disabled="@(HasChanges || IsBusy)"
+                               data-test-id="@TestIdHelper.For("ThemeDetailDuplicate")" />
+                <MudIconButton Icon="@Icons.Material.Filled.FileDownload"
+                               title="@Translate("Export")"
+                               OnClick="ExportTheme"
+                               Disabled="@(HasChanges || IsBusy)"
+                               data-test-id="@TestIdHelper.For("ThemeDetailExport")" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                               Color="Color.Error"
+                               title="@Translate("Delete")"
+                               OnClick="DeleteTheme"
+                               Disabled="@(!CanEditTheme || IsBusy)"
+                               data-test-id="@TestIdHelper.For("ThemeDetailDelete")" />
                 <MudIconButton Icon="@Icons.Material.Outlined.Undo"
                                title="@Translate("Reset")"
                                OnClick="ResetEdits"
@@ -59,10 +80,11 @@
                             {
                                 <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined" data-test-id="@TestIdHelper.For("ThemeDetailApplied")">@Translate("Applied")</MudChip>
                             }
-                            @if (Theme.IsReadOnly)
-                            {
-                                <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined" data-test-id="@TestIdHelper.For("ThemeDetailBundled")">@GetReadOnlySourceLabel(Theme)</MudChip>
-                            }
+                            <MudChip T="string"
+                                     Size="Size.Small"
+                                     Color="@GetSourceChipColor(Theme)"
+                                     Variant="Variant.Outlined"
+                                     data-test-id="@TestIdHelper.For("ThemeDetailSource")">@GetReadOnlySourceLabel(Theme)</MudChip>
                         </div>
 
                         @if (Theme.IsReadOnly)

--- a/src/Lantean.QBTMud.Presentation/Pages/ThemeDetail.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Pages/ThemeDetail.razor.cs
@@ -3,6 +3,7 @@ using Lantean.QBTMud.Application.Services.Localization;
 using Lantean.QBTMud.Core.Interop;
 using Lantean.QBTMud.Core.Models;
 using Lantean.QBTMud.Core.Theming;
+using Lantean.QBTMud.Helpers;
 using Lantean.QBTMud.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -77,6 +78,7 @@ namespace Lantean.QBTMud.Pages
         private bool _hasChanges;
         private bool _isBusy;
         private bool _isLoading;
+        private StorageType _localThemeStorageType = StorageType.LocalStorage;
         private readonly HashSet<string> _loadedFonts = new(StringComparer.OrdinalIgnoreCase);
 
         [Inject]
@@ -182,11 +184,13 @@ namespace Lantean.QBTMud.Pages
         protected override async Task OnParametersSetAsync()
         {
             await ThemeManagerService.EnsureInitialized();
+            _localThemeStorageType = await ThemeManagerService.GetLocalThemeStorageTypeAsync();
             await LoadTheme();
 
             if (_theme is null)
             {
                 await ThemeManagerService.EnsureRepositoryThemesLoaded();
+                _localThemeStorageType = await ThemeManagerService.GetLocalThemeStorageTypeAsync();
                 await LoadTheme();
             }
         }
@@ -229,7 +233,24 @@ namespace Lantean.QBTMud.Pages
             }
 
             var previewTheme = _editorTheme?.Theme ?? _theme.Theme.Theme;
-            await DialogWorkflow.ShowThemePreviewDialog(previewTheme, IsDarkMode);
+            var request = new ThemePreviewDialogRequest(
+                [
+                    new ThemePreviewDialogItem(
+                        _theme.Id,
+                        _editorName,
+                        ThemeDisplayHelper.GetSourceLabel(_theme, _localThemeStorageType, value => Translate(value)),
+                        ThemeSerialization.CloneTheme(previewTheme))
+                ],
+                _theme.Id,
+                ThemePreviewDialogMode.Details,
+                IsDarkMode)
+            {
+                CurrentThemeId = ThemeManagerService.CurrentThemeId,
+                CanSaveAndApply = CanEditTheme && !_isBusy && !HasNameError,
+                SaveAndApplyThemeAsync = CanEditTheme ? SaveAndApplyFromPreviewAsync : null
+            };
+
+            await DialogWorkflow.ShowThemePreviewDialog(request);
         }
 
         protected Task NameChanged(string value)
@@ -318,9 +339,86 @@ namespace Lantean.QBTMud.Pages
 
         protected string GetReadOnlySourceLabel(ThemeCatalogItem theme)
         {
-            return theme.Source == ThemeSource.Repository
-                ? Translate("Repository")
-                : Translate("Bundled");
+            return ThemeDisplayHelper.GetSourceLabel(theme, _localThemeStorageType, value => Translate(value));
+        }
+
+        protected Color GetSourceChipColor(ThemeCatalogItem theme)
+        {
+            return ThemeDisplayHelper.GetSourceChipColor(theme);
+        }
+
+        protected async Task RenameTheme()
+        {
+            if (!CanEditTheme || _theme is null || _hasChanges || _isBusy)
+            {
+                return;
+            }
+
+            await RunBusy(async () =>
+            {
+                var name = await DialogWorkflow.ShowStringFieldDialog(Translate("Rename Theme"), Translate("Name"), _theme.Name);
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    return;
+                }
+
+                var definition = ThemeSerialization.CloneDefinition(_theme.Theme);
+                definition.Id = _theme.Id;
+                definition.Name = name.Trim();
+
+                await ThemeManagerService.SaveLocalTheme(definition);
+                await RefreshTheme();
+            });
+        }
+
+        protected async Task DuplicateTheme()
+        {
+            if (_theme is null || _hasChanges || _isBusy)
+            {
+                return;
+            }
+
+            await RunBusy(async () =>
+            {
+                var clone = await ThemeActionHelper.DuplicateThemeAsync(_theme, DialogWorkflow, (value, args) => Translate(value, args));
+                if (clone is null)
+                {
+                    return;
+                }
+
+                await ThemeManagerService.SaveLocalTheme(clone);
+                NavigateToThemeDetails(clone.Id);
+            });
+        }
+
+        protected async Task ExportTheme()
+        {
+            if (_theme is null || _hasChanges || _isBusy)
+            {
+                return;
+            }
+
+            await RunBusy(() => ThemeActionHelper.ExportThemeAsync(_theme, JSRuntime, (value, args) => Translate(value, args)));
+        }
+
+        protected async Task DeleteTheme()
+        {
+            if (!CanEditTheme || _theme is null || _isBusy)
+            {
+                return;
+            }
+
+            await RunBusy(async () =>
+            {
+                var confirmed = await DialogWorkflow.ShowConfirmDialog(Translate("Delete theme?"), Translate("Delete '%1'?", [_theme.Name]));
+                if (!confirmed)
+                {
+                    return;
+                }
+
+                await ThemeManagerService.DeleteLocalTheme(_theme.Id);
+                NavigateBack();
+            });
         }
 
         private Task LoadTheme()
@@ -369,6 +467,12 @@ namespace Lantean.QBTMud.Pages
             await InvokeAsync(StateHasChanged);
         }
 
+        private void NavigateToThemeDetails(string themeId)
+        {
+            var escaped = Uri.EscapeDataString(themeId);
+            NavigationManager.NavigateTo($"./themes/{escaped}");
+        }
+
         private async Task SaveEditsInternal(bool applyAfterSave)
         {
             if (!CanEditTheme || _theme is null || _editorTheme is null)
@@ -407,6 +511,23 @@ namespace Lantean.QBTMud.Pages
                     await ThemeManagerService.ApplyTheme(_theme.Id);
                 }
             });
+        }
+
+        private async Task<bool> SaveAndApplyFromPreviewAsync()
+        {
+            if (!CanEditTheme || _theme is null || _editorTheme is null || HasNameError)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(_editorName))
+            {
+                _nameError = Translate("Name is required.");
+                return false;
+            }
+
+            await SaveEditsInternal(true);
+            return true;
         }
 
         private async Task RunBusy(Func<Task> action)
@@ -474,6 +595,11 @@ namespace Lantean.QBTMud.Pages
         private string Translate(string value)
         {
             return LanguageLocalizer.Translate("AppThemeDetail", value);
+        }
+
+        private string Translate(string value, params object[] args)
+        {
+            return LanguageLocalizer.Translate("AppThemeDetail", value, args);
         }
     }
 }

--- a/src/Lantean.QBTMud.Presentation/Pages/Themes.razor
+++ b/src/Lantean.QBTMud.Presentation/Pages/Themes.razor
@@ -126,27 +126,17 @@
                                        OnClick="@(e => OpenThemeDetails(theme))"
                                        Disabled="@IsBusy"
                                        data-test-id="@TestIdHelper.For($"ThemeDetails-{theme.Id}")" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Visibility"
+                                       title="@Translate("Preview")"
+                                       OnClick="@(e => PreviewTheme(theme))"
+                                       Disabled="@IsBusy"
+                                       data-test-id="@TestIdHelper.For($"ThemePreview-{theme.Id}")" />
                         <MudIconButton Icon="@Icons.Material.Filled.CheckCircle"
                                        Color="Color.Primary"
                                        title="@Translate("Apply")"
                                        OnClick="@(e => ApplyTheme(theme))"
                                        Disabled="@(!CanApplyTheme(theme) || IsBusy)"
                                        data-test-id="@TestIdHelper.For($"ThemeApply-{theme.Id}")" />
-                        <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                                       title="@Translate("Duplicate")"
-                                       OnClick="@(e => DuplicateTheme(theme))"
-                                       Disabled="@IsBusy"
-                                       data-test-id="@TestIdHelper.For($"ThemeDuplicate-{theme.Id}")" />
-                        <MudIconButton Icon="@Icons.Material.Filled.FileDownload"
-                                       title="@Translate("Export")"
-                                       OnClick="@(e => ExportTheme(theme))"
-                                       Disabled="@IsBusy"
-                                       data-test-id="@TestIdHelper.For($"ThemeExport-{theme.Id}")" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                       title="@Translate("Rename")"
-                                       OnClick="@(e => RenameTheme(theme))"
-                                       Disabled="@(!CanEditTheme(theme) || IsBusy)"
-                                       data-test-id="@TestIdHelper.For($"ThemeRename-{theme.Id}")" />
                         <MudIconButton Icon="@Icons.Material.Filled.Delete"
                                        Color="Color.Error"
                                        title="@Translate("Delete")"

--- a/src/Lantean.QBTMud.Presentation/Pages/Themes.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Pages/Themes.razor.cs
@@ -1,17 +1,15 @@
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using Lantean.QBTMud.Application.Services;
 using Lantean.QBTMud.Application.Services.Localization;
 using Lantean.QBTMud.Components.UI;
 using Lantean.QBTMud.Core;
-using Lantean.QBTMud.Core.Interop;
 using Lantean.QBTMud.Core.Models;
 using Lantean.QBTMud.Core.Theming;
+using Lantean.QBTMud.Helpers;
 using Lantean.QBTMud.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.Utilities;
 
@@ -27,6 +25,7 @@ namespace Lantean.QBTMud.Pages
         private const string _actionsColumnId = "actions";
 
         private readonly Dictionary<string, RenderFragment<RowContext<ThemeCatalogItem>>> _columnRenderFragments = [];
+        private StorageType _localThemeStorageType = StorageType.LocalStorage;
         private bool _isBusy;
 
         [Inject]
@@ -45,13 +44,13 @@ namespace Lantean.QBTMud.Pages
         protected NavigationManager NavigationManager { get; set; } = default!;
 
         [Inject]
-        protected IJSRuntime JSRuntime { get; set; } = default!;
-
-        [Inject]
         protected ILanguageLocalizer LanguageLocalizer { get; set; } = default!;
 
         [CascadingParameter(Name = "DrawerOpen")]
         public bool DrawerOpen { get; set; }
+
+        [CascadingParameter(Name = "IsDarkMode")]
+        public bool IsDarkMode { get; set; }
 
         protected DynamicTable<ThemeCatalogItem>? Table { get; set; }
 
@@ -97,6 +96,7 @@ namespace Lantean.QBTMud.Pages
         {
             await ThemeManagerService.EnsureInitialized();
             await ThemeManagerService.EnsureRepositoryThemesLoaded();
+            _localThemeStorageType = await ThemeManagerService.GetLocalThemeStorageTypeAsync();
             if (ThemeManagerService.LastReloadHadRepositoryIssues)
             {
                 SnackbarWorkflow.ShowTransientMessage(Translate("Unable to load theme repository. Showing bundled and local themes only."), Severity.Warning);
@@ -119,6 +119,7 @@ namespace Lantean.QBTMud.Pages
             try
             {
                 await ThemeManagerService.ReloadServerThemes();
+                _localThemeStorageType = await ThemeManagerService.GetLocalThemeStorageTypeAsync();
                 if (ThemeManagerService.LastReloadHadRepositoryIssues)
                 {
                     SnackbarWorkflow.ShowTransientMessage(Translate("Unable to load theme repository. Showing bundled and local themes only."), Severity.Warning);
@@ -153,93 +154,24 @@ namespace Lantean.QBTMud.Pages
             }
         }
 
-        protected async Task DuplicateTheme(ThemeCatalogItem theme)
+        protected async Task PreviewTheme(ThemeCatalogItem theme)
         {
             if (_isBusy)
             {
                 return;
             }
 
-            _isBusy = true;
-            try
+            var request = new ThemePreviewDialogRequest(
+                ThemeDisplayHelper.CreatePreviewItems(ThemeEntries, _localThemeStorageType, value => Translate(value)),
+                theme.Id,
+                ThemePreviewDialogMode.Catalogue,
+                IsDarkMode)
             {
-                var defaultName = Translate("%1 Copy", theme.Name);
-                var name = await DialogWorkflow.ShowStringFieldDialog(Translate("Duplicate Theme"), Translate("Name"), defaultName);
-                if (string.IsNullOrWhiteSpace(name))
-                {
-                    return;
-                }
+                CurrentThemeId = ThemeManagerService.CurrentThemeId,
+                ApplyThemeAsync = ApplyPreviewThemeAsync
+            };
 
-                var clone = ThemeSerialization.CloneDefinition(theme.Theme);
-                clone.Id = Guid.NewGuid().ToString("N");
-                clone.Name = name.Trim();
-
-                await ThemeManagerService.SaveLocalTheme(clone);
-                NavigateToDetails(clone.Id);
-            }
-            finally
-            {
-                _isBusy = false;
-            }
-        }
-
-        protected async Task ExportTheme(ThemeCatalogItem theme)
-        {
-            if (_isBusy)
-            {
-                return;
-            }
-
-            _isBusy = true;
-            try
-            {
-                var definition = ThemeSerialization.CloneDefinition(theme.Theme);
-                definition.Id = theme.Id;
-                definition.Name = theme.Name;
-
-                var json = ThemeSerialization.SerializeDefinition(definition, writeIndented: true);
-                var safeName = SanitizeFileName(theme.Name);
-                var dataUrl = BuildJsonDataUrl(json);
-
-                await JSRuntime.FileDownload(dataUrl, $"{safeName}.json");
-            }
-            finally
-            {
-                _isBusy = false;
-            }
-        }
-
-        protected async Task RenameTheme(ThemeCatalogItem theme)
-        {
-            if (_isBusy)
-            {
-                return;
-            }
-
-            if (!CanEditTheme(theme))
-            {
-                return;
-            }
-
-            _isBusy = true;
-            try
-            {
-                var name = await DialogWorkflow.ShowStringFieldDialog(Translate("Rename Theme"), Translate("Name"), theme.Name);
-                if (string.IsNullOrWhiteSpace(name))
-                {
-                    return;
-                }
-
-                var definition = ThemeSerialization.CloneDefinition(theme.Theme);
-                definition.Id = theme.Id;
-                definition.Name = name.Trim();
-
-                await ThemeManagerService.SaveLocalTheme(definition);
-            }
-            finally
-            {
-                _isBusy = false;
-            }
+            await DialogWorkflow.ShowThemePreviewDialog(request);
         }
 
         protected async Task DeleteTheme(ThemeCatalogItem theme)
@@ -379,22 +311,12 @@ namespace Lantean.QBTMud.Pages
 
         protected string GetSourceLabel(ThemeCatalogItem theme)
         {
-            return theme.Source switch
-            {
-                ThemeSource.Local => Translate("Local"),
-                ThemeSource.Repository => Translate("Repository"),
-                _ => Translate("Bundled")
-            };
+            return ThemeDisplayHelper.GetSourceLabel(theme, _localThemeStorageType, value => Translate(value));
         }
 
         protected Color GetSourceChipColor(ThemeCatalogItem theme)
         {
-            return theme.Source switch
-            {
-                ThemeSource.Local => Color.Default,
-                ThemeSource.Repository => Color.Secondary,
-                _ => Color.Info
-            };
+            return ThemeDisplayHelper.GetSourceChipColor(theme);
         }
 
         private void NavigateToDetails(string themeId)
@@ -463,34 +385,34 @@ namespace Lantean.QBTMud.Pages
             };
         }
 
-        private string SanitizeFileName(string name)
+        private async Task<bool> ApplyPreviewThemeAsync(string themeId)
         {
-            var invalidChars = Path.GetInvalidFileNameChars();
-            var builder = new StringBuilder(name.Length);
-
-            foreach (var ch in name)
+            if (_isBusy)
             {
-                builder.Append(invalidChars.Contains(ch) ? '-' : ch);
+                return false;
             }
 
-            var sanitized = builder.ToString().Trim();
-            if (string.IsNullOrWhiteSpace(sanitized))
+            var theme = ThemeEntries.FirstOrDefault(entry => string.Equals(entry.Id, themeId, StringComparison.Ordinal));
+            if (theme is null || !CanApplyTheme(theme))
             {
-                return Translate("theme");
+                return false;
             }
 
-            return sanitized;
+            _isBusy = true;
+            try
+            {
+                await ThemeManagerService.ApplyTheme(themeId);
+                return true;
+            }
+            finally
+            {
+                _isBusy = false;
+            }
         }
 
         private string Translate(string value, params object[] args)
         {
             return LanguageLocalizer.Translate("AppThemes", value, args);
-        }
-
-        private static string BuildJsonDataUrl(string json)
-        {
-            var escaped = Uri.EscapeDataString(json);
-            return $"data:application/json;charset=utf-8,{escaped}";
         }
 
         private static string GetSwatchStyle(ThemeCatalogItem theme, ThemePaletteColor colorType, bool useDarkPalette)

--- a/src/Lantean.QBTMud.Presentation/Services/DialogWorkflow.cs
+++ b/src/Lantean.QBTMud.Presentation/Services/DialogWorkflow.cs
@@ -838,19 +838,19 @@ namespace Lantean.QBTMud.Services
         /// <summary>
         /// Shows a theme preview dialog.
         /// </summary>
-        /// <param name="theme">The theme to preview.</param>
-        /// <param name="isDarkMode">Whether to start the preview in dark mode.</param>
-        public async Task ShowThemePreviewDialog(MudTheme theme, bool isDarkMode)
+        /// <param name="request">The preview request.</param>
+        public async Task ShowThemePreviewDialog(ThemePreviewDialogRequest request)
         {
-            if (theme is null)
+            ArgumentNullException.ThrowIfNull(request);
+
+            if (request.Items.Count == 0)
             {
-                throw new ArgumentNullException(nameof(theme));
+                throw new ArgumentException("At least one preview theme is required.", nameof(request));
             }
 
             var parameters = new DialogParameters
             {
-                { nameof(ThemePreviewDialog.Theme), theme },
-                { nameof(ThemePreviewDialog.IsDarkMode), isDarkMode }
+                { nameof(ThemePreviewDialog.Request), request }
             };
             var options = FullScreenDialogOptions with
             {

--- a/src/Lantean.QBTMud.Presentation/Services/IDialogWorkflow.cs
+++ b/src/Lantean.QBTMud.Presentation/Services/IDialogWorkflow.cs
@@ -235,8 +235,7 @@ namespace Lantean.QBTMud.Services
         /// <summary>
         /// Shows a theme preview dialog.
         /// </summary>
-        /// <param name="theme">The theme to preview.</param>
-        /// <param name="isDarkMode">Whether to start the preview in dark mode.</param>
-        Task ShowThemePreviewDialog(MudTheme theme, bool isDarkMode);
+        /// <param name="request">The preview request.</param>
+        Task ShowThemePreviewDialog(ThemePreviewDialogRequest request);
     }
 }

--- a/test/Lantean.QBTMud.Infrastructure.Test/Services/ThemeManagerServiceTests.cs
+++ b/test/Lantean.QBTMud.Infrastructure.Test/Services/ThemeManagerServiceTests.cs
@@ -22,6 +22,8 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         private static readonly HttpResponseMessage _notFoundResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound);
 
         private readonly TestLocalStorageService _localStorage;
+        private readonly IStorageRoutingService _storageRoutingService;
+        private readonly IWebApiCapabilityService _webApiCapabilityService;
         private readonly IThemeFontCatalog _fontCatalog;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILanguageLocalizer _languageLocalizer;
@@ -32,6 +34,8 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         public ThemeManagerServiceTests()
         {
             _localStorage = new TestLocalStorageService();
+            _storageRoutingService = Mock.Of<IStorageRoutingService>();
+            _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
             _fontCatalog = Mock.Of<IThemeFontCatalog>();
             _httpClientFactory = Mock.Of<IHttpClientFactory>();
             _languageLocalizer = Mock.Of<ILanguageLocalizer>();
@@ -40,8 +44,17 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
             Mock.Get(_languageLocalizer)
                 .Setup(localizer => localizer.Translate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>()))
                 .Returns((string _, string source, object[] _) => source);
+            Mock.Get(_storageRoutingService)
+                .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StorageRoutingSettings.Default);
+            Mock.Get(_storageRoutingService)
+                .Setup(service => service.ResolveEffectiveStorageType(It.IsAny<string>(), It.IsAny<StorageRoutingSettings>(), It.IsAny<bool>()))
+                .Returns(StorageType.LocalStorage);
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false));
             SetupThemeRepositoryIndexUrl(string.Empty);
-            _target = new ThemeManagerService(_httpClientFactory, _localStorage, _fontCatalog, _languageLocalizer, _appSettingsService, _logger);
+            _target = new ThemeManagerService(_httpClientFactory, _localStorage, _storageRoutingService, _webApiCapabilityService, _fontCatalog, _languageLocalizer, _appSettingsService, _logger);
         }
 
         [Fact]

--- a/test/Lantean.QBTMud.Presentation.Test/Components/Dialogs/ThemePreviewDialogTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Components/Dialogs/ThemePreviewDialogTests.cs
@@ -1,26 +1,39 @@
 using AwesomeAssertions;
 using Bunit;
+using Lantean.QBTMud.Application.Services;
 using Lantean.QBTMud.Components.Dialogs;
 using Lantean.QBTMud.Components.UI;
-using Microsoft.AspNetCore.Components.Web;
+using Lantean.QBTMud.Core.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
 using MudBlazor;
 
 namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
 {
     public sealed class ThemePreviewDialogTests : RazorComponentTestBase<ThemePreviewDialog>
     {
+        private readonly Mock<IKeyboardService> _keyboardServiceMock;
         private readonly ThemePreviewDialogTestDriver _target;
 
         public ThemePreviewDialogTests()
         {
+            _keyboardServiceMock = new Mock<IKeyboardService>();
+            _keyboardServiceMock.Setup(service => service.RegisterKeypressEvent(It.IsAny<KeyboardEvent>(), It.IsAny<Func<KeyboardEvent, Task>>())).Returns(Task.CompletedTask);
+            _keyboardServiceMock.Setup(service => service.UnregisterKeypressEvent(It.IsAny<KeyboardEvent>())).Returns(Task.CompletedTask);
+            _keyboardServiceMock.Setup(service => service.Focus()).Returns(Task.CompletedTask);
+            _keyboardServiceMock.Setup(service => service.UnFocus()).Returns(Task.CompletedTask);
+
+            TestContext.Services.RemoveAll<IKeyboardService>();
+            TestContext.Services.AddSingleton(_keyboardServiceMock.Object);
+
             _target = new ThemePreviewDialogTestDriver(TestContext);
         }
 
         [Fact]
-        public async Task GIVEN_NullTheme_WHEN_Rendered_THEN_UsesPreviewScope()
+        public async Task GIVEN_Request_WHEN_Rendered_THEN_UsesPreviewScope()
         {
-            var dialog = await _target.RenderDialogAsync(null, false);
+            var dialog = await _target.RenderDialogAsync(CreateCatalogueRequest());
 
             var provider = dialog.Component.FindComponent<MudThemeProvider>();
 
@@ -31,7 +44,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
         [Fact]
         public async Task GIVEN_DarkModeEnabled_WHEN_Toggled_THEN_IconUpdates()
         {
-            var dialog = await _target.RenderDialogAsync(new MudTheme(), true);
+            var dialog = await _target.RenderDialogAsync(CreateCatalogueRequest(isDarkMode: true));
 
             var toggle = FindComponentByTestId<MudIconButton>(dialog.Component, "ThemePreviewToggleMode");
             toggle.Instance.Icon.Should().Be(Icons.Material.Filled.LightMode);
@@ -43,27 +56,90 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
         }
 
         [Fact]
-        public async Task GIVEN_CloseClicked_WHEN_Invoked_THEN_DialogCloses()
+        public async Task GIVEN_CatalogueRequest_WHEN_PreviousAndNextUsed_THEN_NavigatesWithinBounds()
         {
-            var dialog = await _target.RenderDialogAsync(new MudTheme(), false);
+            var dialog = await _target.RenderDialogAsync(CreateCatalogueRequest());
 
-            var close = FindComponentByTestId<MudIconButton>(dialog.Component, "ThemePreviewClose");
-            await close.Find("button").ClickAsync(new MouseEventArgs());
+            var name = FindComponentByTestId<MudText>(dialog.Component, "ThemePreviewName");
+            GetChildContentText(name.Instance.ChildContent).Should().Be("First");
 
+            var previous = FindComponentByTestId<MudIconButton>(dialog.Component, "ThemePreviewPrevious");
+            var next = FindComponentByTestId<MudIconButton>(dialog.Component, "ThemePreviewNext");
+            previous.Instance.Disabled.Should().BeTrue();
+            next.Instance.Disabled.Should().BeFalse();
+
+            await dialog.Component.InvokeAsync(() => next.Instance.OnClick.InvokeAsync());
+
+            name = FindComponentByTestId<MudText>(dialog.Component, "ThemePreviewName");
+            GetChildContentText(name.Instance.ChildContent).Should().Be("Second");
+            next = FindComponentByTestId<MudIconButton>(dialog.Component, "ThemePreviewNext");
+            next.Instance.Disabled.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GIVEN_CatalogueRequest_WHEN_ApplyClicked_THEN_InvokesCallbackAndCloses()
+        {
+            var appliedThemeId = string.Empty;
+            var request = CreateCatalogueRequest();
+            request.ApplyThemeAsync = themeId =>
+            {
+                appliedThemeId = themeId;
+                return Task.FromResult(true);
+            };
+
+            var dialog = await _target.RenderDialogAsync(request);
+            var apply = FindComponentByTestId<MudButton>(dialog.Component, "ThemePreviewApply");
+
+            await dialog.Component.InvokeAsync(() => apply.Instance.OnClick.InvokeAsync());
+
+            appliedThemeId.Should().Be("First");
             var result = await dialog.Reference.Result;
             result.Should().NotBeNull();
             result!.Canceled.Should().BeFalse();
         }
 
         [Fact]
-        public async Task GIVEN_NavLinkClicked_WHEN_Invoked_THEN_Completes()
+        public async Task GIVEN_DetailsRequest_WHEN_Rendered_THEN_HidesNavigationAndShowsSaveApply()
         {
-            var dialog = await _target.RenderDialogAsync(new MudTheme(), false);
+            var dialog = await _target.RenderDialogAsync(CreateDetailsRequest());
 
-            var navLink = dialog.Component.FindComponents<CustomNavLink>().First();
-            navLink.Instance.OnClick.HasDelegate.Should().BeTrue();
+            dialog.Component.FindComponents<MudIconButton>()
+                .Any(component => HasTestId(component, "ThemePreviewPrevious"))
+                .Should()
+                .BeFalse();
 
-            await dialog.Component.InvokeAsync(() => navLink.Instance.OnClick.InvokeAsync(new MouseEventArgs()));
+            FindComponentByTestId<MudButton>(dialog.Component, "ThemePreviewSaveApply").Instance.Disabled.Should().BeFalse();
+        }
+
+        private static ThemePreviewDialogRequest CreateCatalogueRequest(bool isDarkMode = false)
+        {
+            var request = new ThemePreviewDialogRequest(
+                [
+                    new ThemePreviewDialogItem("First", "First", "Bundled", new MudTheme()),
+                    new ThemePreviewDialogItem("Second", "Second", "Repository", new MudTheme())
+                ],
+                "First",
+                ThemePreviewDialogMode.Catalogue,
+                isDarkMode)
+            {
+                CurrentThemeId = "Other"
+            };
+
+            request.ApplyThemeAsync = _ => Task.FromResult(true);
+            return request;
+        }
+
+        private static ThemePreviewDialogRequest CreateDetailsRequest()
+        {
+            return new ThemePreviewDialogRequest(
+                [new ThemePreviewDialogItem("ThemeId", "Name", "Local Storage", new MudTheme())],
+                "ThemeId",
+                ThemePreviewDialogMode.Details,
+                false)
+            {
+                CanSaveAndApply = true,
+                SaveAndApplyThemeAsync = () => Task.FromResult(true)
+            };
         }
     }
 
@@ -76,15 +152,14 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
             _testContext = testContext;
         }
 
-        public async Task<ThemePreviewDialogRenderContext> RenderDialogAsync(MudTheme? theme, bool isDarkMode)
+        public async Task<ThemePreviewDialogRenderContext> RenderDialogAsync(ThemePreviewDialogRequest request)
         {
             var provider = _testContext.Render<MudDialogProvider>();
             var dialogService = _testContext.Services.GetRequiredService<IDialogService>();
 
             var parameters = new DialogParameters
             {
-                { nameof(ThemePreviewDialog.Theme), theme },
-                { nameof(ThemePreviewDialog.IsDarkMode), isDarkMode }
+                { nameof(ThemePreviewDialog.Request), request }
             };
 
             var reference = await dialogService.ShowAsync<ThemePreviewDialog>("Theme Preview", parameters);

--- a/test/Lantean.QBTMud.Presentation.Test/Pages/ThemeDetailTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Pages/ThemeDetailTests.cs
@@ -47,6 +47,9 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             Mock.Get(_themeManagerService)
                 .Setup(service => service.ReloadServerThemes())
                 .Returns(Task.CompletedTask);
+            Mock.Get(_themeManagerService)
+                .Setup(service => service.GetLocalThemeStorageTypeAsync())
+                .ReturnsAsync(StorageType.LocalStorage);
 
             SetupFontCatalog(new[] { "Nunito Sans", "Open Sans" });
         }
@@ -92,7 +95,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
         {
             var theme = CreateTheme("ThemeId", "Name", ThemeSource.Local);
             Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowThemePreviewDialog(It.IsAny<MudTheme>(), true))
+                .Setup(workflow => workflow.ShowThemePreviewDialog(It.IsAny<ThemePreviewDialogRequest>()))
                 .Returns(Task.CompletedTask);
 
             var target = RenderPage("ThemeId", new List<ThemeCatalogItem> { theme }, isDarkMode: true);
@@ -101,7 +104,12 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             await target.InvokeAsync(() => previewButton.Instance.OnClick.InvokeAsync());
 
             Mock.Get(_dialogWorkflow)
-                .Verify(workflow => workflow.ShowThemePreviewDialog(It.IsAny<MudTheme>(), true), Times.Once);
+                .Verify(workflow => workflow.ShowThemePreviewDialog(
+                        It.Is<ThemePreviewDialogRequest>(request =>
+                            request.Mode == ThemePreviewDialogMode.Details
+                            && request.IsDarkMode
+                            && request.SelectedThemeId == "ThemeId")),
+                    Times.Once);
         }
 
         [Fact]

--- a/test/Lantean.QBTMud.Presentation.Test/Pages/ThemesTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Pages/ThemesTests.cs
@@ -49,6 +49,9 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             Mock.Get(_themeManagerService)
                 .Setup(service => service.ReloadServerThemes())
                 .Returns(Task.CompletedTask);
+            Mock.Get(_themeManagerService)
+                .Setup(service => service.GetLocalThemeStorageTypeAsync())
+                .ReturnsAsync(StorageType.LocalStorage);
         }
 
         [Fact]
@@ -119,6 +122,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
 
             chips.Should().HaveCount(1);
             chips[0].Instance.Color.Should().Be(Color.Default);
+            GetChildContentText(chips[0].Instance.ChildContent).Should().Be("Local Storage");
         }
 
         [Fact]
@@ -135,6 +139,25 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
 
             chips.Should().HaveCount(1);
             chips[0].Instance.Color.Should().Be(Color.Info);
+        }
+
+        [Fact]
+        public void GIVEN_LocalThemeStoredInClientData_WHEN_Rendered_THEN_ShowsClientDataLabel()
+        {
+            var themes = new List<ThemeCatalogItem>
+            {
+                CreateTheme("ThemeId", "Name", ThemeSource.Local)
+            };
+            Mock.Get(_themeManagerService)
+                .Setup(service => service.GetLocalThemeStorageTypeAsync())
+                .ReturnsAsync(StorageType.ClientData);
+
+            var target = RenderPage(themes);
+
+            var chips = target.FindComponents<MudChip<string>>();
+
+            chips.Should().HaveCount(1);
+            GetChildContentText(chips[0].Instance.ChildContent).Should().Be("Client Data");
         }
 
         [Fact]
@@ -304,89 +327,27 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
         }
 
         [Fact]
-        public async Task GIVEN_DuplicateAccepted_WHEN_Invoked_THEN_SavesAndNavigates()
+        public async Task GIVEN_PreviewClicked_WHEN_Invoked_THEN_ShowsCataloguePreviewDialog()
         {
             var themes = new List<ThemeCatalogItem>
             {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
+                CreateTheme("ThemeId", "Name", ThemeSource.Local),
+                CreateTheme("ThemeIdTwo", "Name Two", ThemeSource.Repository)
             };
             Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Duplicate Theme", "Name", "Name Copy"))
-                .ReturnsAsync("Name Copy");
-            Mock.Get(_themeManagerService)
-                .Setup(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()))
+                .Setup(workflow => workflow.ShowThemePreviewDialog(It.IsAny<ThemePreviewDialogRequest>()))
                 .Returns(Task.CompletedTask);
 
             var target = RenderPage(themes);
 
-            var duplicateButton = FindComponentByTestId<MudIconButton>(target, "ThemeDuplicate-ThemeId");
-            await target.InvokeAsync(() => duplicateButton.Instance.OnClick.InvokeAsync());
+            var previewButton = FindComponentByTestId<MudIconButton>(target, "ThemePreview-ThemeId");
+            await target.InvokeAsync(() => previewButton.Instance.OnClick.InvokeAsync());
 
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(
-                    It.Is<ThemeDefinition>(definition => definition.Name == "Name Copy")),
-                Times.Once);
-            TestContext.Services.GetRequiredService<NavigationManager>().Uri.Should().Contain("/themes/");
-        }
-
-        [Fact]
-        public async Task GIVEN_DuplicateCanceled_WHEN_Invoked_THEN_DoesNotSave()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
-            };
-            Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Duplicate Theme", "Name", "Name Copy"))
-                .ReturnsAsync((string?)null);
-
-            var target = RenderPage(themes);
-
-            var duplicateButton = FindComponentByTestId<MudIconButton>(target, "ThemeDuplicate-ThemeId");
-            await target.InvokeAsync(() => duplicateButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task GIVEN_RenameCanceled_WHEN_Invoked_THEN_DoesNotSave()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
-            };
-            Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Rename Theme", "Name", "Name"))
-                .ReturnsAsync((string?)null);
-
-            var target = RenderPage(themes);
-
-            var renameButton = FindComponentByTestId<MudIconButton>(target, "ThemeRename-ThemeId");
-            await target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task GIVEN_RenameAccepted_WHEN_Invoked_THEN_SavesTheme()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
-            };
-            Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Rename Theme", "Name", "Name"))
-                .ReturnsAsync("Renamed");
-            Mock.Get(_themeManagerService)
-                .Setup(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()))
-                .Returns(Task.CompletedTask);
-
-            var target = RenderPage(themes);
-
-            var renameButton = FindComponentByTestId<MudIconButton>(target, "ThemeRename-ThemeId");
-            await target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(
-                    It.Is<ThemeDefinition>(definition => definition.Name == "Renamed")),
+            Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowThemePreviewDialog(
+                    It.Is<ThemePreviewDialogRequest>(request =>
+                        request.Mode == ThemePreviewDialogMode.Catalogue
+                        && request.SelectedThemeId == "ThemeId"
+                        && request.Items.Count == 2)),
                 Times.Once);
         }
 
@@ -494,54 +455,6 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             await target.InvokeAsync(() => reloadButton.Instance.OnClick.InvokeAsync());
 
             Mock.Get(_snackbar).Verify(snackbar => snackbar.Add("Unable to load theme repository. Showing bundled and local themes only.", Severity.Warning, null, null), Times.Once);
-        }
-
-        [Fact]
-        public async Task GIVEN_ExportInvoked_WHEN_Clicked_THEN_TriggersDownload()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Theme/Name", ThemeSource.Local)
-            };
-            var downloadInvocation = TestContext.JSInterop.SetupVoid("qbt.triggerFileDownload", _ => true);
-            downloadInvocation.SetVoidResult();
-
-            var target = RenderPage(themes);
-
-            var exportButton = FindComponentByTestId<MudIconButton>(target, "ThemeExport-ThemeId");
-            await target.InvokeAsync(() => exportButton.Instance.OnClick.InvokeAsync());
-
-            var arguments = downloadInvocation.Invocations
-                .Select(invocation => invocation.Arguments.OfType<string>().ToList())
-                .Single();
-            arguments.Should().HaveCount(2);
-            arguments.Last().Should().Be("Theme-Name.json");
-        }
-
-        [Fact]
-        public async Task GIVEN_ExportInProgress_WHEN_ClickedAgain_THEN_SkipsSecondExport()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "ThemeName", ThemeSource.Local)
-            };
-            var downloadInvocation = TestContext.JSInterop.SetupVoid("qbt.triggerFileDownload", _ => true);
-            var target = RenderPage(themes);
-            var exportButton = FindComponentByTestId<MudIconButton>(target, "ThemeExport-ThemeId");
-
-            var firstExportTask = target.InvokeAsync(() => exportButton.Instance.OnClick.InvokeAsync());
-
-            target.WaitForAssertion(() =>
-            {
-                downloadInvocation.Invocations.Should().HaveCount(1);
-            });
-
-            await target.InvokeAsync(() => exportButton.Instance.OnClick.InvokeAsync());
-
-            downloadInvocation.Invocations.Should().HaveCount(1);
-
-            downloadInvocation.SetVoidResult();
-            await firstExportTask;
         }
 
         [Fact]
@@ -873,28 +786,6 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
         }
 
         [Fact]
-        public async Task GIVEN_ExportWithWhitespaceName_WHEN_Invoked_THEN_UsesDefaultFileName()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "   ", ThemeSource.Local)
-            };
-            var downloadInvocation = TestContext.JSInterop.SetupVoid("qbt.triggerFileDownload", _ => true);
-            downloadInvocation.SetVoidResult();
-
-            var target = RenderPage(themes);
-
-            var exportButton = FindComponentByTestId<MudIconButton>(target, "ThemeExport-ThemeId");
-            await target.InvokeAsync(() => exportButton.Instance.OnClick.InvokeAsync());
-
-            var arguments = downloadInvocation.Invocations
-                .Select(invocation => invocation.Arguments.OfType<string>().ToList())
-                .Single();
-            arguments.Should().HaveCount(2);
-            arguments.Last().Should().Be("theme.json");
-        }
-
-        [Fact]
         public async Task GIVEN_ApplyInProgress_WHEN_ClickedAgain_THEN_SkipsSecondApply()
         {
             var themes = new List<ThemeCatalogItem>
@@ -925,106 +816,6 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
 
             applyTaskSource.SetResult();
             await firstApplyTask;
-        }
-
-        [Fact]
-        public async Task GIVEN_DuplicateInProgress_WHEN_ClickedAgain_THEN_SkipsSecondDuplicate()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
-            };
-            Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Duplicate Theme", "Name", "Name Copy"))
-                .ReturnsAsync("Name Copy");
-            var saveTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            Mock.Get(_themeManagerService)
-                .Setup(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()))
-                .Returns(saveTaskSource.Task);
-
-            var target = RenderPage(themes);
-            var duplicateButton = FindComponentByTestId<MudIconButton>(target, "ThemeDuplicate-ThemeId");
-
-            var firstDuplicateTask = target.InvokeAsync(() => duplicateButton.Instance.OnClick.InvokeAsync());
-
-            target.WaitForAssertion(() =>
-            {
-                Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog("Duplicate Theme", "Name", "Name Copy"), Times.Once);
-            });
-
-            await target.InvokeAsync(() => duplicateButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog("Duplicate Theme", "Name", "Name Copy"), Times.Once);
-
-            saveTaskSource.SetResult();
-            await firstDuplicateTask;
-        }
-
-        [Fact]
-        public async Task GIVEN_RenameReadOnlyTheme_WHEN_Clicked_THEN_SkipsRename()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Server)
-            };
-
-            var target = RenderPage(themes);
-            var renameButton = FindComponentByTestId<MudIconButton>(target, "ThemeRename-ThemeId");
-
-            await target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task GIVEN_RenameRepositoryTheme_WHEN_Clicked_THEN_SkipsRename()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Repository)
-            };
-
-            var target = RenderPage(themes);
-            var renameButton = FindComponentByTestId<MudIconButton>(target, "ThemeRename-ThemeId");
-
-            await target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
-            Mock.Get(_themeManagerService).Verify(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task GIVEN_RenameInProgress_WHEN_ClickedAgain_THEN_SkipsSecondRename()
-        {
-            var themes = new List<ThemeCatalogItem>
-            {
-                CreateTheme("ThemeId", "Name", ThemeSource.Local)
-            };
-            Mock.Get(_dialogWorkflow)
-                .Setup(workflow => workflow.ShowStringFieldDialog("Rename Theme", "Name", "Name"))
-                .ReturnsAsync("Renamed");
-            var saveTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            Mock.Get(_themeManagerService)
-                .Setup(service => service.SaveLocalTheme(It.IsAny<ThemeDefinition>()))
-                .Returns(saveTaskSource.Task);
-
-            var target = RenderPage(themes);
-            var renameButton = FindComponentByTestId<MudIconButton>(target, "ThemeRename-ThemeId");
-
-            var firstRenameTask = target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            target.WaitForAssertion(() =>
-            {
-                Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog("Rename Theme", "Name", "Name"), Times.Once);
-            });
-
-            await target.InvokeAsync(() => renameButton.Instance.OnClick.InvokeAsync());
-
-            Mock.Get(_dialogWorkflow).Verify(workflow => workflow.ShowStringFieldDialog("Rename Theme", "Name", "Name"), Times.Once);
-
-            saveTaskSource.SetResult();
-            await firstRenameTask;
         }
 
         [Fact]

--- a/test/Lantean.QBTMud.Presentation.Test/Services/DialogWorkflowTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Services/DialogWorkflowTests.cs
@@ -1955,28 +1955,32 @@ namespace Lantean.QBTMud.Presentation.Test.Services
         }
 
         [Fact]
-        public async Task GIVEN_NullTheme_WHEN_ShowThemePreviewDialog_THEN_Throws()
+        public async Task GIVEN_NullRequest_WHEN_ShowThemePreviewDialog_THEN_Throws()
         {
-            Func<Task> act = async () => await _target.ShowThemePreviewDialog(null!, true);
+            Func<Task> act = async () => await _target.ShowThemePreviewDialog(null!);
 
             await act.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [Fact]
-        public async Task GIVEN_Theme_WHEN_ShowThemePreviewDialog_THEN_ShowsDialog()
+        public async Task GIVEN_Request_WHEN_ShowThemePreviewDialog_THEN_ShowsDialog()
         {
             var reference = new Mock<IDialogReference>();
             Mock.Get(_dialogService)
                 .Setup(s => s.ShowAsync<ThemePreviewDialog>("Theme Preview", It.IsAny<DialogParameters>(), It.IsAny<DialogOptions>()))
                 .ReturnsAsync(reference.Object);
 
-            var theme = new MudTheme();
+            var request = new ThemePreviewDialogRequest(
+                [new ThemePreviewDialogItem("ThemeId", "Name", "Bundled", new MudTheme())],
+                "ThemeId",
+                ThemePreviewDialogMode.Catalogue,
+                true);
 
-            await _target.ShowThemePreviewDialog(theme, true);
+            await _target.ShowThemePreviewDialog(request);
 
             Mock.Get(_dialogService).Verify(s => s.ShowAsync<ThemePreviewDialog>(
                     "Theme Preview",
-                    It.Is<DialogParameters>(parameters => HasThemePreviewDialogParameters(parameters, theme, true)),
+                    It.Is<DialogParameters>(parameters => HasThemePreviewDialogParameters(parameters, request)),
                     It.Is<DialogOptions>(options => HasThemePreviewDialogOptions(options))),
                 Times.Once);
         }
@@ -2362,21 +2366,15 @@ namespace Lantean.QBTMud.Presentation.Test.Services
                    && ReferenceEquals(parameters[nameof(SubMenuDialog.Torrents)], torrents);
         }
 
-        private static bool HasThemePreviewDialogParameters(DialogParameters parameters, MudTheme theme, bool isDarkMode)
+        private static bool HasThemePreviewDialogParameters(DialogParameters parameters, ThemePreviewDialogRequest request)
         {
-            if (!HasParameter(parameters, nameof(ThemePreviewDialog.Theme))
-                || !ReferenceEquals(parameters[nameof(ThemePreviewDialog.Theme)], theme))
+            if (!HasParameter(parameters, nameof(ThemePreviewDialog.Request))
+                || !ReferenceEquals(parameters[nameof(ThemePreviewDialog.Request)], request))
             {
                 return false;
             }
 
-            if (!HasParameter(parameters, nameof(ThemePreviewDialog.IsDarkMode)))
-            {
-                return false;
-            }
-
-            var isDarkModeValue = parameters[nameof(ThemePreviewDialog.IsDarkMode)] as bool?;
-            return isDarkModeValue.HasValue && isDarkModeValue.Value == isDarkMode;
+            return true;
         }
 
         private static bool HasThemePreviewDialogOptions(DialogOptions options)


### PR DESCRIPTION
## Summary

Reorganises theme management so the theme list acts as a catalogue, the details page owns theme-specific management actions, and the preview dialog supports non-destructive browsing before applying a theme.

## What Changed

- Added explicit preview-dialog models and workflow contracts so the theme preview can run in catalogue mode or details mode with mode-specific actions.
- Reworked the theme preview dialog into a browsable preview experience with previous/next navigation, keyboard navigation, local dark/light toggling, explicit `Apply` / `Save & apply` actions, and mobile-specific dialog layout adjustments.
- Moved duplicate, export, rename, and delete management into the theme details experience, while simplifying the theme list to `Details`, `Preview`, `Apply`, and `Delete`.
- Added shared presentation helpers for theme display metadata and duplicate/export behaviour to keep list and details flows consistent.
- Exposed the effective local-theme storage type from the theme manager so local themes can be labelled in the UI by their resolved storage location (`Client Data` or `Local Storage`) rather than the internal `Local` source value.
- Updated the themes and theme-details pages to use the new storage-aware source labelling and preview-dialog workflow.

## Testing

- Extended infrastructure coverage for the theme manager changes, including the new effective storage-type path used by the UI.
- Updated dialog workflow tests for the new preview request contract.
- Reworked theme preview dialog component tests to cover catalogue/details modes, navigation, apply behaviour, and dialog closing.
- Updated themes-page and theme-details-page tests to cover the new action ownership, preview entry points, and storage-aware source labels.

## Notes

- The preview browser does not change the active theme while browsing; theme changes only happen through explicit `Apply` or `Save & apply`.
- The preview dialog now uses dialog-scoped mobile sizing so the preview gets more usable space on narrow screens without changing global dialog chrome.
