### PR TITLE
Update theme bootstrap persistence

### DIFF
--- a/src/Lantean.QBTMud.Application/Services/IStorageCatalogService.cs
+++ b/src/Lantean.QBTMud.Application/Services/IStorageCatalogService.cs
@@ -3,25 +3,32 @@ using Lantean.QBTMud.Core.Models;
 namespace Lantean.QBTMud.Application.Services
 {
     /// <summary>
-    /// Provides definitions for all routed qbtmud storage items.
+    /// Provides definitions for qbtmud storage items.
     /// </summary>
     public interface IStorageCatalogService
     {
         /// <summary>
-        /// Gets the catalog groups.
+        /// Gets the user-configurable routed storage groups.
         /// </summary>
         IReadOnlyList<StorageCatalogGroupDefinition> Groups { get; }
 
         /// <summary>
-        /// Gets all catalog items.
+        /// Gets all user-configurable routed storage items.
         /// </summary>
         IReadOnlyList<StorageCatalogItemDefinition> Items { get; }
 
         /// <summary>
-        /// Matches a runtime storage key to a catalog item.
+        /// Matches a runtime storage key to a user-configurable routed storage item.
         /// </summary>
         /// <param name="key">The runtime storage key without qbtmud prefix.</param>
         /// <returns>The matching catalog item, or <see langword="null"/> when unmatched.</returns>
         StorageCatalogItemDefinition? MatchItemByKey(string key);
+
+        /// <summary>
+        /// Determines whether a runtime storage key is fixed to local storage and excluded from routed storage settings.
+        /// </summary>
+        /// <param name="key">The runtime storage key without qbtmud prefix.</param>
+        /// <returns><see langword="true"/> when the key is fixed to local storage; otherwise <see langword="false"/>.</returns>
+        bool IsLocalStorageOnlyKey(string key);
     }
 }

--- a/src/Lantean.QBTMud.Application/Services/StorageCatalogService.cs
+++ b/src/Lantean.QBTMud.Application/Services/StorageCatalogService.cs
@@ -11,6 +11,8 @@ namespace Lantean.QBTMud.Application.Services
         private readonly IReadOnlyList<StorageCatalogItemDefinition> _items;
         private readonly IReadOnlyDictionary<string, StorageCatalogItemDefinition> _exactMatchLookup;
         private readonly IReadOnlyList<StorageCatalogItemDefinition> _prefixItems;
+        private readonly IReadOnlyDictionary<string, StorageCatalogItemDefinition> _localOnlyExactMatchLookup;
+        private readonly IReadOnlyList<StorageCatalogItemDefinition> _localOnlyPrefixItems;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StorageCatalogService"/> class.
@@ -25,6 +27,14 @@ namespace Lantean.QBTMud.Application.Services
                 .Where(item => item.MatchMode == StorageCatalogItemMatchMode.ExactKey)
                 .ToDictionary(item => item.MatchPattern, item => item, StringComparer.Ordinal);
             _prefixItems = _items
+                .Where(item => item.MatchMode == StorageCatalogItemMatchMode.PrefixPattern)
+                .OrderByDescending(item => item.MatchPattern.Length)
+                .ToList();
+            var localOnlyItems = BuildLocalOnlyItems();
+            _localOnlyExactMatchLookup = localOnlyItems
+                .Where(item => item.MatchMode == StorageCatalogItemMatchMode.ExactKey)
+                .ToDictionary(item => item.MatchPattern, item => item, StringComparer.Ordinal);
+            _localOnlyPrefixItems = localOnlyItems
                 .Where(item => item.MatchMode == StorageCatalogItemMatchMode.PrefixPattern)
                 .OrderByDescending(item => item.MatchPattern.Length)
                 .ToList();
@@ -69,6 +79,23 @@ namespace Lantean.QBTMud.Application.Services
             }
 
             return _prefixItems.FirstOrDefault(prefixItem => normalizedKey.StartsWith(prefixItem.MatchPattern, StringComparison.Ordinal));
+        }
+
+        /// <inheritdoc />
+        public bool IsLocalStorageOnlyKey(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            var normalizedKey = key.Trim();
+            if (_localOnlyExactMatchLookup.ContainsKey(normalizedKey))
+            {
+                return true;
+            }
+
+            return _localOnlyPrefixItems.Any(prefixItem => normalizedKey.StartsWith(prefixItem.MatchPattern, StringComparison.Ordinal));
         }
 
         private static IReadOnlyList<StorageCatalogGroupDefinition> BuildGroups()
@@ -143,6 +170,18 @@ namespace Lantean.QBTMud.Application.Services
                     [
                         new StorageCatalogItemDefinition("tables.dynamic", "tables", "Dynamic table preferences", StorageCatalogItemMatchMode.PrefixPattern, "DynamicTable", StorageItemSerializationMode.Json)
                     ])
+            ];
+        }
+
+        private static IReadOnlyList<StorageCatalogItemDefinition> BuildLocalOnlyItems()
+        {
+            return
+            [
+                new StorageCatalogItemDefinition("internal.storage-routing-settings", "internal", "Storage routing settings", StorageCatalogItemMatchMode.ExactKey, StorageRoutingSettings.StorageKey, StorageItemSerializationMode.Json),
+                new StorageCatalogItemDefinition("internal.bootstrap-css-light", "internal", "Bootstrap theme light CSS", StorageCatalogItemMatchMode.ExactKey, "ThemeManager.BootstrapCss.Light", StorageItemSerializationMode.RawString),
+                new StorageCatalogItemDefinition("internal.bootstrap-css-dark", "internal", "Bootstrap theme dark CSS", StorageCatalogItemMatchMode.ExactKey, "ThemeManager.BootstrapCss.Dark", StorageItemSerializationMode.RawString),
+                new StorageCatalogItemDefinition("internal.bootstrap-is-dark", "internal", "Bootstrap theme dark mode", StorageCatalogItemMatchMode.ExactKey, "ThemeManager.BootstrapIsDark", StorageItemSerializationMode.Json),
+                new StorageCatalogItemDefinition("internal.bootstrap-font-family", "internal", "Bootstrap theme font family", StorageCatalogItemMatchMode.ExactKey, "ThemeManager.BootstrapFontFamily", StorageItemSerializationMode.RawString)
             ];
         }
     }

--- a/src/Lantean.QBTMud.Application/Services/StorageRoutingService.cs
+++ b/src/Lantean.QBTMud.Application/Services/StorageRoutingService.cs
@@ -137,6 +137,11 @@ namespace Lantean.QBTMud.Application.Services
             var matchedItem = _storageCatalogService.MatchItemByKey(key.Trim());
             if (matchedItem is null)
             {
+                if (_storageCatalogService.IsLocalStorageOnlyKey(key))
+                {
+                    return StorageType.LocalStorage;
+                }
+
                 return settings.MasterStorageType;
             }
 

--- a/src/Lantean.QBTMud.Presentation/Layout/MainLayout.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Layout/MainLayout.razor.cs
@@ -65,6 +65,7 @@ namespace Lantean.QBTMud.Layout
         private int _lastErrorCount;
         private bool _pendingThemeUpdate;
         private bool _pendingThemeModeUpdate = true;
+        private bool _persistBootstrapThemeForPendingThemeModeUpdate;
         private bool _pendingBootstrapThemeUpdate;
         private bool _pendingBootstrapThemeRemoval;
         private bool _bootstrapThemeRemoved;
@@ -185,7 +186,9 @@ namespace Lantean.QBTMud.Layout
             if (_pendingThemeModeUpdate && _themeInitialized)
             {
                 _pendingThemeModeUpdate = false;
-                await ApplyThemeModePreferenceAsync();
+                var persistBootstrapTheme = _persistBootstrapThemeForPendingThemeModeUpdate;
+                _persistBootstrapThemeForPendingThemeModeUpdate = false;
+                await ApplyThemeModePreferenceAsync(persistBootstrapTheme);
             }
 
             if (_pendingThemeUpdate && _themeInitialized)
@@ -291,13 +294,7 @@ namespace Lantean.QBTMud.Layout
 
         private void OnThemeChanged(object? sender, ThemeChangedEventArgs args)
         {
-            Theme = args.Theme;
-            _pendingFontFamily = args.FontFamily;
-            _pendingThemeUpdate = true;
-            _pendingBootstrapThemeUpdate = true;
-            _pendingBootstrapThemeRemoval = true;
-            _hasAppliedTheme = true;
-            StateHasChanged();
+            ApplyTheme(args.Theme, args.FontFamily, persistBootstrapTheme: _themeInitialized, removeBootstrapTheme: true);
         }
 
         private void OnThemeModePreferenceChanged(object? sender, ThemeModePreferenceChangedEventArgs args)
@@ -310,6 +307,7 @@ namespace Lantean.QBTMud.Layout
 
             _themeModePreference = themeModePreference;
             _pendingThemeModeUpdate = true;
+            _persistBootstrapThemeForPendingThemeModeUpdate = true;
             StateHasChanged();
         }
 
@@ -326,7 +324,7 @@ namespace Lantean.QBTMud.Layout
                 return;
             }
 
-            OnThemeChanged(this, new ThemeChangedEventArgs(current.Theme.Theme, ThemeManagerService.CurrentFontFamily, current.Id));
+            ApplyTheme(current.Theme.Theme, ThemeManagerService.CurrentFontFamily, persistBootstrapTheme: false, removeBootstrapTheme: true);
         }
 
         private async Task LoadPendingFontAsync()
@@ -345,7 +343,23 @@ namespace Lantean.QBTMud.Layout
             await JSRuntime.LoadGoogleFont(url, fontId);
         }
 
-        private async Task ApplyThemeModePreferenceAsync()
+        private void ApplyTheme(MudTheme theme, string fontFamily, bool persistBootstrapTheme, bool removeBootstrapTheme)
+        {
+            Theme = theme;
+            _pendingFontFamily = fontFamily;
+            _pendingThemeUpdate = true;
+            _pendingBootstrapThemeUpdate = persistBootstrapTheme;
+
+            if (removeBootstrapTheme)
+            {
+                _pendingBootstrapThemeRemoval = true;
+            }
+
+            _hasAppliedTheme = true;
+            StateHasChanged();
+        }
+
+        private async Task ApplyThemeModePreferenceAsync(bool persistBootstrapTheme)
         {
             var resolvedIsDarkMode = _themeModePreference switch
             {
@@ -356,7 +370,10 @@ namespace Lantean.QBTMud.Layout
             var darkModeChanged = IsDarkMode != resolvedIsDarkMode;
 
             IsDarkMode = resolvedIsDarkMode;
-            _pendingBootstrapThemeUpdate = true;
+            if (persistBootstrapTheme && darkModeChanged)
+            {
+                _pendingBootstrapThemeUpdate = true;
+            }
 
             if (darkModeChanged)
             {

--- a/src/Lantean.QBTMud.Presentation/Layout/MainLayout.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Layout/MainLayout.razor.cs
@@ -374,11 +374,22 @@ namespace Lantean.QBTMud.Layout
             {
                 _pendingBootstrapThemeUpdate = true;
             }
+            else if (!persistBootstrapTheme && await ShouldPersistBootstrapThemeForResolvedModeAsync(resolvedIsDarkMode))
+            {
+                _pendingBootstrapThemeUpdate = true;
+            }
 
             if (darkModeChanged)
             {
                 StateHasChanged();
             }
+        }
+
+        private async Task<bool> ShouldPersistBootstrapThemeForResolvedModeAsync(bool resolvedIsDarkMode)
+        {
+            var storedBootstrapThemeIsDark = await LocalStorage.GetItemAsync<bool?>(_bootstrapThemeIsDarkStorageKey);
+
+            return storedBootstrapThemeIsDark.HasValue && storedBootstrapThemeIsDark.Value != resolvedIsDarkMode;
         }
 
         private async Task PersistBootstrapThemeAsync()

--- a/test/Lantean.QBTMud.Application.Test/Services/StorageCatalogServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/StorageCatalogServiceTests.cs
@@ -59,11 +59,37 @@ namespace Lantean.QBTMud.Application.Test.Services
         }
 
         [Fact]
+        public void GIVEN_LocalStorageOnlyKey_WHEN_MatchItemByKeyInvoked_THEN_ReturnsNull()
+        {
+            var result = _target.MatchItemByKey(StorageRoutingSettings.StorageKey);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GIVEN_LocalStorageOnlyKey_WHEN_IsLocalStorageOnlyKeyInvoked_THEN_ReturnsTrue()
+        {
+            var storageRoutingResult = _target.IsLocalStorageOnlyKey(StorageRoutingSettings.StorageKey);
+            var bootstrapResult = _target.IsLocalStorageOnlyKey("ThemeManager.BootstrapCss.Light");
+
+            storageRoutingResult.Should().BeTrue();
+            bootstrapResult.Should().BeTrue();
+        }
+
+        [Fact]
         public void GIVEN_UnknownKey_WHEN_MatchItemByKeyInvoked_THEN_ReturnsNull()
         {
             var result = _target.MatchItemByKey("Unknown.Storage.Key");
 
             result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GIVEN_UnknownKey_WHEN_IsLocalStorageOnlyKeyInvoked_THEN_ReturnsFalse()
+        {
+            var result = _target.IsLocalStorageOnlyKey("Unknown.Storage.Key");
+
+            result.Should().BeFalse();
         }
     }
 }

--- a/test/Lantean.QBTMud.Application.Test/Services/StorageRoutingServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/StorageRoutingServiceTests.cs
@@ -93,6 +93,21 @@ namespace Lantean.QBTMud.Application.Test.Services
         }
 
         [Fact]
+        public void GIVEN_LocalStorageOnlyKey_WHEN_MasterStorageTypeIsClientData_THEN_ShouldResolveToLocalStorage()
+        {
+            var settings = new StorageRoutingSettings
+            {
+                MasterStorageType = StorageType.ClientData
+            };
+
+            var bootstrapStorageType = _target.ResolveEffectiveStorageType("ThemeManager.BootstrapCss.Light", settings, supportsClientData: true);
+            var routingSettingsStorageType = _target.ResolveEffectiveStorageType(StorageRoutingSettings.StorageKey, settings, supportsClientData: true);
+
+            bootstrapStorageType.Should().Be(StorageType.LocalStorage);
+            routingSettingsStorageType.Should().Be(StorageType.LocalStorage);
+        }
+
+        [Fact]
         public async Task GIVEN_ExactJsonKeyInLocalStorage_WHEN_SavingClientDataRouting_THEN_ShouldMigrateValueAndRemoveLocalEntry()
         {
             Mock.Get(_webApiCapabilityService)

--- a/test/Lantean.QBTMud.Presentation.Test/Layout/MainLayoutTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Layout/MainLayoutTests.cs
@@ -315,6 +315,52 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
         }
 
         [Fact]
+        public async Task GIVEN_SystemThemeModePreferenceAndStoredBootstrapModeMismatch_WHEN_Rendered_THEN_PersistsBootstrapThemeOnInitialize()
+        {
+            await _localStorage.SetItemAsync("ThemeManager.BootstrapIsDark", false, Xunit.TestContext.Current.CancellationToken);
+
+            _currentThemeModePreference = ThemeModePreference.System;
+            var systemDarkModeInvocation = TestContext.JSInterop.Setup<bool>("mudThemeProvider.isDarkMode", _ => true);
+            systemDarkModeInvocation.SetResult(true);
+            var writesBeforeRender = _localStorage.WriteCount;
+
+            var target = RenderLayout(CreateProbeBody());
+
+            target.WaitForAssertion(() =>
+            {
+                target.FindComponent<MudThemeProvider>().Instance.GetState(x => x.IsDarkMode).Should().BeTrue();
+
+                var snapshot = _localStorage.Snapshot();
+                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Light");
+                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Dark");
+                snapshot.Should().ContainKey("ThemeManager.BootstrapIsDark");
+                snapshot["ThemeManager.BootstrapIsDark"].Should().Be(true);
+                _localStorage.WriteCount.Should().BeGreaterThan(writesBeforeRender);
+            });
+        }
+
+        [Fact]
+        public async Task GIVEN_SystemThemeModePreferenceAndStoredBootstrapModeMatch_WHEN_Rendered_THEN_DoesNotPersistBootstrapThemeOnInitialize()
+        {
+            await _localStorage.SetItemAsync("ThemeManager.BootstrapIsDark", true, Xunit.TestContext.Current.CancellationToken);
+
+            _currentThemeModePreference = ThemeModePreference.System;
+            var systemDarkModeInvocation = TestContext.JSInterop.Setup<bool>("mudThemeProvider.isDarkMode", _ => true);
+            systemDarkModeInvocation.SetResult(true);
+            var writesBeforeRender = _localStorage.WriteCount;
+
+            var target = RenderLayout(CreateProbeBody());
+
+            target.WaitForAssertion(() =>
+            {
+                target.FindComponent<MudThemeProvider>().Instance.GetState(x => x.IsDarkMode).Should().BeTrue();
+                _localStorage.WriteCount.Should().Be(writesBeforeRender);
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Light");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Dark");
+            });
+        }
+
+        [Fact]
         public void GIVEN_LightThemeModePreference_WHEN_Rendered_THEN_DoesNotQuerySystemDarkModePreference()
         {
             _currentThemeModePreference = ThemeModePreference.Light;

--- a/test/Lantean.QBTMud.Presentation.Test/Layout/MainLayoutTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Layout/MainLayoutTests.cs
@@ -226,11 +226,19 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
 
             var target = RenderLayout(CreateProbeBody());
 
-            target.FindComponent<DrawerProbe>().Should().NotBeNull();
+            target.WaitForAssertion(() =>
+            {
+                target.FindComponent<DrawerProbe>().Should().NotBeNull();
+                TestContext.JSInterop.Invocations.Should().Contain(inv => inv.Identifier == "qbt.removeBootstrapTheme");
+                _localStorage.WriteCount.Should().Be(0);
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Light");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Dark");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapIsDark");
+            });
         }
 
         [Fact]
-        public void GIVEN_CurrentThemeAvailable_WHEN_Rendered_THEN_AppliesCurrentThemeOnInitialize()
+        public void GIVEN_CurrentThemeAvailable_WHEN_Rendered_THEN_DoesNotPersistBootstrapThemeOnInitialize()
         {
             var currentTheme = new ThemeCatalogItem(
                 id: "ThemeId",
@@ -253,10 +261,12 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
 
             target.WaitForAssertion(() =>
             {
-                var snapshot = _localStorage.Snapshot();
-                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Light");
-                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Dark");
-                snapshot.Should().ContainKey("ThemeManager.BootstrapFontFamily");
+                TestContext.JSInterop.Invocations.Should().Contain(inv => inv.Identifier == "qbt.removeBootstrapTheme");
+                _localStorage.WriteCount.Should().Be(0);
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Light");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapCss.Dark");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapIsDark");
+                _localStorage.Snapshot().Should().NotContainKey("ThemeManager.BootstrapFontFamily");
             });
         }
 
@@ -436,7 +446,7 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
             var baselineMode = baselineSnapshot.TryGetValue("ThemeManager.BootstrapIsDark", out var value)
                 ? value as bool?
                 : null;
-            baselineMode.Should().BeTrue();
+            baselineMode.Should().BeNull();
 
             await target.InvokeAsync(() => themeProvider.Instance.SystemDarkModeChangedAsync(false));
 
@@ -444,7 +454,8 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
             var updatedMode = updatedSnapshot.TryGetValue("ThemeManager.BootstrapIsDark", out var updatedValue)
                 ? updatedValue as bool?
                 : null;
-            updatedMode.Should().BeTrue();
+            updatedMode.Should().BeNull();
+            _localStorage.WriteCount.Should().Be(0);
         }
 
         [Fact]
@@ -460,7 +471,16 @@ namespace Lantean.QBTMud.Presentation.Test.Layout
 
             await target.InvokeAsync(() => RaiseThemeModePreferenceChanged(ThemeModePreference.Light));
 
-            target.WaitForAssertion(() => themeProvider.Instance.GetState(x => x.IsDarkMode).Should().BeFalse());
+            target.WaitForAssertion(() =>
+            {
+                themeProvider.Instance.GetState(x => x.IsDarkMode).Should().BeFalse();
+
+                var snapshot = _localStorage.Snapshot();
+                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Light");
+                snapshot.Should().ContainKey("ThemeManager.BootstrapCss.Dark");
+                snapshot.Should().ContainKey("ThemeManager.BootstrapIsDark");
+                snapshot["ThemeManager.BootstrapIsDark"].Should().Be(false);
+            });
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Stops `MainLayout` from rewriting the bootstrap theme cache on every normal startup, while still refreshing the cached bootstrap theme when the active theme or effective theme mode actually changes.

## What Changed

- Split theme application in `MainLayout` from bootstrap cache persistence so initial theme application no longer rewrites bootstrap CSS, dark-mode state, or font-family values on every load.
- Persist bootstrap theme storage when the selected theme changes or when a theme mode preference change alters the effective dark/light bootstrap output.
- Added a startup check for `ThemeModePreference.System` so the bootstrap cache is refreshed only when the stored bootstrap mode no longer matches the current OS colour-scheme preference.
- Marked bootstrap theme keys and storage routing settings as local-storage-only catalog entries so storage routing cannot move them into client data.
- Updated storage routing resolution to force those internal keys to remain in local storage even when the master or group routing setting is `ClientData`.

## Testing

- Added `MainLayout` regression coverage proving bootstrap theme values are not rewritten during ordinary initialisation when nothing theme-relevant changed.
- Added `MainLayout` coverage proving bootstrap theme values are persisted when the theme changes, when the theme mode preference changes, and when system mode on startup no longer matches the cached bootstrap mode.
- Added storage catalog tests covering local-storage-only key detection.
- Added storage routing tests covering resolution of bootstrap and routing-setting keys to local storage even when broader routing settings target client data.

## Notes

- This addresses issue #84 by keeping the bootstrap cache aligned with actual theme changes without reintroducing unconditional startup writes for all users.
