### PR TITLE
Update framework and api client and use WebApiCompatibilityProfile

### DIFF
--- a/src/Lantean.QBTMud.Application/Lantean.QBTMud.Application.csproj
+++ b/src/Lantean.QBTMud.Application/Lantean.QBTMud.Application.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.1.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lantean.QBTMud.Core/Lantean.QBTMud.Core.csproj
+++ b/src/Lantean.QBTMud.Core/Lantean.QBTMud.Core.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.1.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lantean.QBTMud.Core/Models/WebApiCapabilityState.cs
+++ b/src/Lantean.QBTMud.Core/Models/WebApiCapabilityState.cs
@@ -3,34 +3,12 @@ namespace Lantean.QBTMud.Core.Models
     /// <summary>
     /// Represents detected Web API capability information for the current session.
     /// </summary>
-    public sealed class WebApiCapabilityState
+    public sealed record WebApiCapabilityState
     {
-        private static readonly Version _trackerErrorFiltersMinimumVersion = new(2, 15, 1);
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="WebApiCapabilityState"/> class.
+        /// Gets the Web API version, when available.
         /// </summary>
-        /// <param name="rawWebApiVersion">The raw Web API version string.</param>
-        /// <param name="parsedWebApiVersion">The parsed Web API version, when valid.</param>
-        /// <param name="supportsClientData">A value indicating whether ClientData endpoints are supported.</param>
-        public WebApiCapabilityState(string? rawWebApiVersion, Version? parsedWebApiVersion, bool supportsClientData)
-        {
-            RawWebApiVersion = string.IsNullOrWhiteSpace(rawWebApiVersion)
-                ? null
-                : rawWebApiVersion.Trim();
-            ParsedWebApiVersion = parsedWebApiVersion;
-            SupportsClientData = supportsClientData;
-        }
-
-        /// <summary>
-        /// Gets the raw Web API version string.
-        /// </summary>
-        public string? RawWebApiVersion { get; }
-
-        /// <summary>
-        /// Gets the parsed Web API version, when available.
-        /// </summary>
-        public Version? ParsedWebApiVersion { get; }
+        public Version? WebApiVersion { get; }
 
         /// <summary>
         /// Gets a value indicating whether ClientData endpoints are supported.
@@ -40,13 +18,19 @@ namespace Lantean.QBTMud.Core.Models
         /// <summary>
         /// Gets a value indicating whether tracker error filter buckets are supported.
         /// </summary>
-        public bool SupportsTrackerErrorFilters
+        public bool SupportsTrackerErrorFilters { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebApiCapabilityState"/> class.
+        /// </summary>
+        /// <param name="webApiVersion">The Web API version, when available.</param>
+        /// <param name="supportsClientData">A value indicating whether ClientData endpoints are supported.</param>
+        /// <param name="supportsTrackerErrorFilters">A value indicating whether tracker error filter buckets are supported.</param>
+        public WebApiCapabilityState(Version? webApiVersion, bool supportsClientData, bool supportsTrackerErrorFilters = false)
         {
-            get
-            {
-                return ParsedWebApiVersion is not null
-                    && ParsedWebApiVersion >= _trackerErrorFiltersMinimumVersion;
-            }
+            WebApiVersion = webApiVersion;
+            SupportsClientData = supportsClientData;
+            SupportsTrackerErrorFilters = supportsTrackerErrorFilters;
         }
     }
 }

--- a/src/Lantean.QBTMud.Infrastructure/Lantean.QBTMud.Infrastructure.csproj
+++ b/src/Lantean.QBTMud.Infrastructure/Lantean.QBTMud.Infrastructure.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.1.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lantean.QBTMud.Infrastructure/Services/WebApiCapabilityService.cs
+++ b/src/Lantean.QBTMud.Infrastructure/Services/WebApiCapabilityService.cs
@@ -9,8 +9,6 @@ namespace Lantean.QBTMud.Infrastructure.Services
     /// </summary>
     public sealed class WebApiCapabilityService : IWebApiCapabilityService
     {
-        private static readonly Version _clientDataMinimumVersion = new(2, 13, 1);
-
         private readonly SemaphoreSlim _initializationSemaphore = new(1, 1);
         private readonly IApiClient _apiClient;
         private WebApiCapabilityState? _cachedState;
@@ -35,27 +33,27 @@ namespace Lantean.QBTMud.Infrastructure.Services
                     return _cachedState;
                 }
 
-                var versionResult = await _apiClient.GetAPIVersionAsync();
+                var versionResult = await _apiClient.GetAPIVersionAsync(cancellationToken);
                 if (versionResult.IsFailure)
                 {
-                    return new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false);
+                    return new WebApiCapabilityState(
+                        webApiVersion: null,
+                        supportsClientData: false,
+                        supportsTrackerErrorFilters: false);
                 }
 
-                var rawVersion = versionResult.Value;
-                rawVersion = string.IsNullOrWhiteSpace(rawVersion)
-                    ? null
-                    : rawVersion.Trim();
-
-                if (rawVersion is null || !Version.TryParse(rawVersion, out var parsedVersion))
+                if (!WebApiCompatibilityProfile.TryCreate(versionResult.Value, out var compatibilityProfile))
                 {
-                    _cachedState = new WebApiCapabilityState(rawVersion, parsedWebApiVersion: null, supportsClientData: false);
-                    return _cachedState;
+                    return new WebApiCapabilityState(
+                        webApiVersion: null,
+                        supportsClientData: false,
+                        supportsTrackerErrorFilters: false);
                 }
 
                 _cachedState = new WebApiCapabilityState(
-                    rawVersion,
-                    parsedVersion,
-                    supportsClientData: parsedVersion >= _clientDataMinimumVersion);
+                    compatibilityProfile.WebApiVersion,
+                    supportsClientData: compatibilityProfile.SupportsClientData,
+                    supportsTrackerErrorFilters: compatibilityProfile.SupportsTrackerErrorFilters);
                 return _cachedState;
             }
             finally

--- a/src/Lantean.QBTMud.Infrastructure/Services/WebApiCapabilityService.cs
+++ b/src/Lantean.QBTMud.Infrastructure/Services/WebApiCapabilityService.cs
@@ -44,10 +44,11 @@ namespace Lantean.QBTMud.Infrastructure.Services
 
                 if (!WebApiCompatibilityProfile.TryCreate(versionResult.Value, out var compatibilityProfile))
                 {
-                    return new WebApiCapabilityState(
+                    _cachedState = new WebApiCapabilityState(
                         webApiVersion: null,
                         supportsClientData: false,
                         supportsTrackerErrorFilters: false);
+                    return _cachedState;
                 }
 
                 _cachedState = new WebApiCapabilityState(

--- a/src/Lantean.QBTMud.Presentation/Components/AppSettings/StorageAppSettingsTab.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Components/AppSettings/StorageAppSettingsTab.razor.cs
@@ -59,7 +59,7 @@ namespace Lantean.QBTMud.Components.AppSettingsTabs
 
         protected bool IsLoadingInitialStorageEntries => IsActive && !_hasLoadedInitialStorageEntries && IsStorageBusy;
 
-        protected WebApiCapabilityState WebApiCapabilityState { get; private set; } = new(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false);
+        protected WebApiCapabilityState WebApiCapabilityState { get; private set; } = new(webApiVersion: null, supportsClientData: false);
 
         private int _loadedReloadToken = -1;
         private bool _hasLoadedCapabilityState;
@@ -263,12 +263,12 @@ namespace Lantean.QBTMud.Components.AppSettingsTabs
 
         protected string GetWebApiVersionText()
         {
-            if (string.IsNullOrWhiteSpace(WebApiCapabilityState.RawWebApiVersion))
+            if (WebApiCapabilityState.WebApiVersion is null)
             {
                 return TranslateSettings("Unavailable");
             }
 
-            return WebApiCapabilityState.RawWebApiVersion;
+            return WebApiCapabilityState.WebApiVersion.ToString();
         }
 
         protected string GetClientDataSupportText()
@@ -435,15 +435,15 @@ namespace Lantean.QBTMud.Components.AppSettingsTabs
             }
             catch (HttpRequestException)
             {
-                return new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false);
+                return new WebApiCapabilityState(webApiVersion: null, supportsClientData: false);
             }
             catch (JsonException)
             {
-                return new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false);
+                return new WebApiCapabilityState(webApiVersion: null, supportsClientData: false);
             }
             catch (InvalidOperationException)
             {
-                return new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false);
+                return new WebApiCapabilityState(webApiVersion: null, supportsClientData: false);
             }
         }
 

--- a/src/Lantean.QBTMud.Presentation/Lantean.QBTMud.Presentation.csproj
+++ b/src/Lantean.QBTMud.Presentation/Lantean.QBTMud.Presentation.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="BlazorFlags" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.1.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lantean.QBTMud/Lantean.QBTMud.csproj
+++ b/src/Lantean.QBTMud/Lantean.QBTMud.csproj
@@ -158,11 +158,11 @@
     <PackageReference Include="Blazor.HashRouting" Version="1.2.0" />
     <PackageReference Include="BlazorFlags" Version="1.0.0" />
     <PackageReference Include="ByteSize" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.1.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Lantean.QBTMud.Application.Test/Services/SettingsStorageServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/SettingsStorageServiceTests.cs
@@ -80,7 +80,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             IReadOnlyDictionary<string, object?>? payload = null;
             Mock.Get(_clientDataStorageAdapter)
@@ -106,7 +106,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             await _target.SetItemAsStringAsync("WebUiLocalization.PreferredLocale.v1", "en", TestContext.Current.CancellationToken);
 
@@ -129,7 +129,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
@@ -152,7 +152,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -181,7 +181,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
@@ -204,7 +204,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException("cancelled"));
@@ -228,7 +228,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -253,7 +253,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -280,7 +280,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.Failure);
@@ -301,7 +301,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException("cancelled"));
@@ -329,7 +329,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
@@ -352,7 +352,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             IReadOnlyDictionary<string, object?>? payload = null;
             Mock.Get(_clientDataStorageAdapter)
@@ -378,7 +378,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -405,7 +405,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
@@ -429,7 +429,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException("cancelled"));
@@ -453,7 +453,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.Success);
@@ -497,7 +497,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -523,7 +523,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             IReadOnlyDictionary<string, object?>? payload = null;
             Mock.Get(_clientDataStorageAdapter)
@@ -550,7 +550,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException("cancelled"));
@@ -596,7 +596,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 });
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException("cancelled"));

--- a/test/Lantean.QBTMud.Application.Test/Services/StorageDiagnosticsServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/StorageDiagnosticsServiceTests.cs
@@ -55,7 +55,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -117,7 +117,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.Success);
@@ -142,7 +142,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 .ReturnsAsync(3);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -171,7 +171,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 .ReturnsAsync([new BrowserStorageEntry("QbtMud.LocalOnly", "{}")]);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var result = await _target.GetEntriesAsync(TestContext.Current.CancellationToken);
 
@@ -193,7 +193,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 .ReturnsAsync([new BrowserStorageEntry("QbtMud.LocalOnly", "{}")]);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
@@ -213,7 +213,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.RemovePrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
@@ -257,7 +257,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             await _target.RemoveEntryAsync(StorageType.ClientData, "QbtMud.Key", TestContext.Current.CancellationToken);
 
@@ -289,7 +289,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var removed = await _target.ClearEntriesAsync(StorageType.ClientData, TestContext.Current.CancellationToken);
 
@@ -307,7 +307,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -328,7 +328,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
@@ -349,7 +349,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(
@@ -378,7 +378,7 @@ namespace Lantean.QBTMud.Application.Test.Services
                 .ReturnsAsync([new BrowserStorageEntry("QbtMud.Local", null)]);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromEntries(

--- a/test/Lantean.QBTMud.Application.Test/Services/StorageRoutingServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/StorageRoutingServiceTests.cs
@@ -112,7 +112,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             await _localStorageService.SetItemAsStringAsync("AppSettings.State.v2", "{\"theme\":\"dark\"}", TestContext.Current.CancellationToken);
 
@@ -142,7 +142,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             await _localStorageService.SetItemAsStringAsync(AppSettings.LegacyStorageKey, "{\"theme\":\"dark\"}", TestContext.Current.CancellationToken);
 
@@ -172,7 +172,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             await _localStorageService.SetItemAsStringAsync("ThemeManager.BootstrapCss.Light", "LightCss", TestContext.Current.CancellationToken);
             await _localStorageService.SetItemAsStringAsync("ThemeManager.BootstrapCss.Dark", "DarkCss", TestContext.Current.CancellationToken);
@@ -203,7 +203,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             _jsRuntime
                 .Setup(runtime => runtime.InvokeAsync<BrowserStorageEntry[]?>(
@@ -237,7 +237,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             await _localStorageService.SetItemAsStringAsync("AppSettings.State.v2", "{invalid-json}", TestContext.Current.CancellationToken);
 
@@ -261,7 +261,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
@@ -335,7 +335,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var act = async () => await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -354,7 +354,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var act = async () => await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -390,7 +390,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IEnumerable<string> keys, CancellationToken _) =>
@@ -428,7 +428,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Loaded(new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
@@ -463,7 +463,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var act = async () => await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -482,7 +482,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
 
             var result = await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -511,7 +511,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             await _localStorageService.SetItemAsStringAsync("AppSettings.State.v2", "{\"enabled\":true}", TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IEnumerable<string> keys, CancellationToken _) =>
@@ -549,7 +549,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IEnumerable<string> keys, CancellationToken _) =>
@@ -591,7 +591,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             var result = await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -618,7 +618,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             var result = await _target.SaveSettingsAsync(new StorageRoutingSettings
             {
@@ -671,7 +671,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             IReadOnlyDictionary<string, object?>? payload = null;
             clientDataStorageAdapter
@@ -728,7 +728,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             _jsRuntime
                 .Setup(runtime => runtime.InvokeAsync<BrowserStorageEntry[]?>(
@@ -765,7 +765,7 @@ namespace Lantean.QBTMud.Application.Test.Services
 
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.StorePrefixedEntriesAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataStorageResult.FromFailure(apiResult));
@@ -799,7 +799,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ClientDataLoadResult.FromFailure(apiResult));
@@ -829,7 +829,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             }, TestContext.Current.CancellationToken);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             Mock.Get(_clientDataStorageAdapter)
                 .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Loaded(new Dictionary<string, JsonElement>(StringComparer.Ordinal)

--- a/test/Lantean.QBTMud.Application.Test/Services/WelcomeWizardPlanBuilderTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/WelcomeWizardPlanBuilderTests.cs
@@ -16,7 +16,7 @@ namespace Lantean.QBTMud.Application.Test.Services
             _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
             _target = new WelcomeWizardPlanBuilder(_welcomeWizardStateService, _webApiCapabilityService);
         }
 
@@ -103,7 +103,7 @@ namespace Lantean.QBTMud.Application.Test.Services
         {
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.12.0", new Version(2, 12, 0), false));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
             Mock.Get(_welcomeWizardStateService)
                 .Setup(service => service.GetStateAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new WelcomeWizardState());

--- a/test/Lantean.QBTMud.Infrastructure.Test/Services/ThemeManagerServiceTests.cs
+++ b/test/Lantean.QBTMud.Infrastructure.Test/Services/ThemeManagerServiceTests.cs
@@ -52,7 +52,7 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
                 .Returns(StorageType.LocalStorage);
             Mock.Get(_webApiCapabilityService)
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState(rawWebApiVersion: null, parsedWebApiVersion: null, supportsClientData: false));
+                .ReturnsAsync(new WebApiCapabilityState(webApiVersion: null, supportsClientData: false));
             SetupThemeRepositoryIndexUrl(string.Empty);
             _target = new ThemeManagerService(_httpClientFactory, _localStorage, _storageRoutingService, _webApiCapabilityService, _fontCatalog, _languageLocalizer, _appSettingsService, _logger);
         }

--- a/test/Lantean.QBTMud.Infrastructure.Test/Services/WebApiCapabilityServiceTests.cs
+++ b/test/Lantean.QBTMud.Infrastructure.Test/Services/WebApiCapabilityServiceTests.cs
@@ -20,75 +20,70 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         public async Task GIVEN_WebApiVersionAtClientDataThreshold_WHEN_GetCapabilityStateAsync_THEN_ShouldReportClientDataSupported()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("2.13.1");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
             result.SupportsClientData.Should().BeTrue();
             result.SupportsTrackerErrorFilters.Should().BeFalse();
-            result.ParsedWebApiVersion.Should().Be(new Version(2, 13, 1));
-            result.RawWebApiVersion.Should().Be("2.13.1");
+            result.WebApiVersion.Should().Be(new Version(2, 13, 1));
         }
 
         [Fact]
         public async Task GIVEN_WebApiVersionAtTrackerFilterThreshold_WHEN_GetCapabilityStateAsync_THEN_ShouldReportTrackerFiltersSupported()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("2.15.1");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
             result.SupportsClientData.Should().BeTrue();
             result.SupportsTrackerErrorFilters.Should().BeTrue();
-            result.ParsedWebApiVersion.Should().Be(new Version(2, 15, 1));
-            result.RawWebApiVersion.Should().Be("2.15.1");
+            result.WebApiVersion.Should().Be(new Version(2, 15, 1));
         }
 
         [Fact]
         public async Task GIVEN_WebApiVersionBeforeThreshold_WHEN_GetCapabilityStateAsync_THEN_ShouldReportClientDataUnsupported()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("2.13.0");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
             result.SupportsClientData.Should().BeFalse();
             result.SupportsTrackerErrorFilters.Should().BeFalse();
-            result.ParsedWebApiVersion.Should().Be(new Version(2, 13, 0));
-            result.RawWebApiVersion.Should().Be("2.13.0");
+            result.WebApiVersion.Should().Be(new Version(2, 13, 0));
         }
 
         [Fact]
         public async Task GIVEN_MalformedWebApiVersion_WHEN_GetCapabilityStateAsync_THEN_ShouldReportUnsupported()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("not-a-version");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
             result.SupportsClientData.Should().BeFalse();
             result.SupportsTrackerErrorFilters.Should().BeFalse();
-            result.ParsedWebApiVersion.Should().BeNull();
-            result.RawWebApiVersion.Should().Be("not-a-version");
+            result.WebApiVersion.Should().BeNull();
         }
 
         [Fact]
         public async Task GIVEN_ApiVersionRequestThrows_WHEN_GetCapabilityStateAsync_THEN_ShouldReportUnsupported()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsFailure(ApiFailureKind.ServerError, "failure", HttpStatusCode.InternalServerError);
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
             result.SupportsClientData.Should().BeFalse();
             result.SupportsTrackerErrorFilters.Should().BeFalse();
-            result.ParsedWebApiVersion.Should().BeNull();
-            result.RawWebApiVersion.Should().BeNull();
+            result.WebApiVersion.Should().BeNull();
         }
 
         [Fact]
@@ -96,7 +91,7 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         {
             var apiClientMock = Mock.Get(_apiClient);
             apiClientMock
-                .SetupSequence(client => client.GetAPIVersionAsync())
+                .SetupSequence(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsFailure(ApiFailureKind.ServerError, "failure", HttpStatusCode.InternalServerError)
                 .ReturnsAsync("2.13.1");
 
@@ -107,14 +102,14 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
             failed.SupportsClientData.Should().BeFalse();
             succeeded.SupportsClientData.Should().BeTrue();
             cached.SupportsClientData.Should().BeTrue();
-            apiClientMock.Verify(client => client.GetAPIVersionAsync(), Times.Exactly(2));
+            apiClientMock.Verify(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Fact]
         public async Task GIVEN_FirstResultCached_WHEN_GetCapabilityStateAsyncCalledTwice_THEN_ShouldCallApiOnce()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("2.13.1");
 
             var first = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
@@ -123,20 +118,19 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
             first.SupportsClientData.Should().BeTrue();
             second.SupportsClientData.Should().BeTrue();
             Mock.Get(_apiClient)
-                .Verify(client => client.GetAPIVersionAsync(), Times.Once);
+                .Verify(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
         public async Task GIVEN_VersionWithWhitespace_WHEN_GetCapabilityStateAsync_THEN_ShouldTrimAndParseVersion()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync(" 2.13.1 ");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
-            result.RawWebApiVersion.Should().Be("2.13.1");
-            result.ParsedWebApiVersion.Should().Be(new Version(2, 13, 1));
+            result.WebApiVersion.Should().Be(new Version(2, 13, 1));
             result.SupportsClientData.Should().BeTrue();
         }
 
@@ -144,13 +138,12 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         public async Task GIVEN_BlankVersion_WHEN_GetCapabilityStateAsync_THEN_ShouldReportUnsupportedWithNullRawValue()
         {
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccessAsync("   ");
 
             var result = await _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
 
-            result.RawWebApiVersion.Should().BeNull();
-            result.ParsedWebApiVersion.Should().BeNull();
+            result.WebApiVersion.Should().BeNull();
             result.SupportsClientData.Should().BeFalse();
         }
 
@@ -159,7 +152,7 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
         {
             var versionCompletion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             Mock.Get(_apiClient)
-                .Setup(client => client.GetAPIVersionAsync())
+                .Setup(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()))
                 .ReturnsSuccess(versionCompletion.Task);
 
             var firstTask = _target.GetCapabilityStateAsync(TestContext.Current.CancellationToken);
@@ -173,7 +166,7 @@ namespace Lantean.QBTMud.Infrastructure.Test.Services
             first.SupportsClientData.Should().BeTrue();
             second.SupportsClientData.Should().BeTrue();
             Mock.Get(_apiClient)
-                .Verify(client => client.GetAPIVersionAsync(), Times.Once);
+                .Verify(client => client.GetAPIVersionAsync(It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/test/Lantean.QBTMud.Presentation.Test/Components/AppSettings/StorageAppSettingsTabCatalogMutationTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Components/AppSettings/StorageAppSettingsTabCatalogMutationTests.cs
@@ -48,7 +48,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.AppSettings
             var webApiCapabilityServiceMock = TestContext.AddSingletonMock<IWebApiCapabilityService>();
             webApiCapabilityServiceMock
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.11.0", new Version(2, 11, 0), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 11, 0), true));
 
             _storageRoutingSettings = StorageRoutingSettings.Default.Clone();
         }

--- a/test/Lantean.QBTMud.Presentation.Test/Components/AppSettings/StorageAppSettingsTabTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Components/AppSettings/StorageAppSettingsTabTests.cs
@@ -27,7 +27,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.AppSettings
                 .ReturnsAsync(Array.Empty<AppStorageEntry>());
             _webApiCapabilityServiceMock
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.11.0", new Version(2, 11, 0), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 11, 0), true));
 
             _storageRoutingSettings = StorageRoutingSettings.Default.Clone();
             _storageRoutingSettings.GroupStorageTypes["themes"] = StorageType.ClientData;

--- a/test/Lantean.QBTMud.Presentation.Test/Components/FiltersNavTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Components/FiltersNavTests.cs
@@ -30,7 +30,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components
 
         private readonly Mock<IWebApiCapabilityService> _webApiCapabilityServiceMock;
         private IRenderedComponent<MudPopoverProvider>? _popoverProvider;
-        private WebApiCapabilityState _webApiCapabilityState = new("2.15.1", new Version(2, 15, 1), supportsClientData: true);
+        private WebApiCapabilityState _webApiCapabilityState = new(new Version(2, 15, 1), true, true);
 
         public FiltersNavTests()
         {
@@ -191,7 +191,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components
 
             var target = RenderFiltersNav(
                 mainData,
-                webApiCapabilityState: new WebApiCapabilityState("2.11.4", new Version(2, 11, 4), supportsClientData: false));
+                webApiCapabilityState: new WebApiCapabilityState(new Version(2, 11, 4), false));
 
             queryState.Tracker.Should().Be(FilterHelper.TRACKER_ALL);
             (await TestContext.LocalStorage.GetItemAsStringAsync(_trackerStorageKey, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
@@ -307,7 +307,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components
 
             var target = RenderFiltersNav(
                 mainData,
-                webApiCapabilityState: new WebApiCapabilityState("2.11.4", new Version(2, 11, 4), supportsClientData: false));
+                webApiCapabilityState: new WebApiCapabilityState(new Version(2, 11, 4), false));
 
             target.FindComponents<CustomNavLink>().Any(component => HasTestId(component, "Tracker-All")).Should().BeTrue();
             target.FindComponents<CustomNavLink>().Any(component => HasTestId(component, "Tracker-Trackerless")).Should().BeTrue();
@@ -891,7 +891,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components
             WebApiCapabilityState? webApiCapabilityState = null)
         {
             _popoverProvider = TestContext.Render<MudPopoverProvider>();
-            _webApiCapabilityState = webApiCapabilityState ?? new WebApiCapabilityState("2.15.1", new Version(2, 15, 1), supportsClientData: true);
+            _webApiCapabilityState = webApiCapabilityState ?? new WebApiCapabilityState(new Version(2, 15, 1), true, true);
 
             var target = TestContext.Render<FiltersNav>(parameters =>
             {

--- a/test/Lantean.QBTMud.Presentation.Test/Pages/AppSettingsTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Pages/AppSettingsTests.cs
@@ -2009,7 +2009,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2061,7 +2061,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2193,7 +2193,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2237,7 +2237,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2285,7 +2285,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2326,7 +2326,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2370,7 +2370,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();
@@ -2409,7 +2409,7 @@ namespace Lantean.QBTMud.Presentation.Test.Pages
             var webApiCapabilityService = new Mock<IWebApiCapabilityService>(MockBehavior.Strict);
             webApiCapabilityService
                 .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new WebApiCapabilityState("2.13.1", new Version(2, 13, 1), true));
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
 
             TestContext.Services.RemoveAll<IStorageRoutingService>();
             TestContext.Services.RemoveAll<IWebApiCapabilityService>();

--- a/tools/ReadmeScreenshots/ReadmeScreenshots.csproj
+++ b/tools/ReadmeScreenshots/ReadmeScreenshots.csproj
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
-    <PackageReference Include="QBittorrent.ApiClient" Version="1.0.0" />
+    <PackageReference Include="QBittorrent.ApiClient" Version="1.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Integrate QBittorrent.ApiClient's WebApiCompatibilityProfile

## What Changed

- Updated AspNetCore to `10.0.8`
- Updated `QBittorrent.ApiClient` to `1.2.0`
- Integrated `QBittorrent.ApiClient`'s `WebApiCompatibilityProfile` into WebApiCapabilityState

## Testing

- Unit tests
