### PR TITLE
Default to client data when existing settings are found

### DIFF
--- a/src/Lantean.QBTMud.Application/QbtMudApplicationServiceCollectionExtensions.cs
+++ b/src/Lantean.QBTMud.Application/QbtMudApplicationServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ namespace Lantean.QBTMud.Application
             services.TryAddScoped<IQBittorrentPreferencesStateService, QBittorrentPreferencesStateService>();
             services.TryAddScoped<IWelcomeWizardStateService, WelcomeWizardStateService>();
             services.TryAddScoped<IWelcomeWizardPlanBuilder, WelcomeWizardPlanBuilder>();
+            services.TryAddScoped<IClientDataPresenceService, ClientDataPresenceService>();
             services.TryAddScoped<IStorageDiagnosticsService, StorageDiagnosticsService>();
             services.TryAddScoped<IStorageRoutingService, StorageRoutingService>();
             services.TryAddScoped<ISettingsStorageService, SettingsStorageService>();

--- a/src/Lantean.QBTMud.Application/Services/ClientDataPresenceService.cs
+++ b/src/Lantean.QBTMud.Application/Services/ClientDataPresenceService.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+
+namespace Lantean.QBTMud.Application.Services
+{
+    /// <summary>
+    /// Detects whether qbtmud-owned ClientData already exists for the current qBittorrent instance.
+    /// </summary>
+    public sealed class ClientDataPresenceService : IClientDataPresenceService
+    {
+        private readonly IWebApiCapabilityService _webApiCapabilityService;
+        private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientDataPresenceService"/> class.
+        /// </summary>
+        /// <param name="webApiCapabilityService">The Web API capability service.</param>
+        /// <param name="clientDataStorageAdapter">The ClientData storage adapter.</param>
+        public ClientDataPresenceService(IWebApiCapabilityService webApiCapabilityService, IClientDataStorageAdapter clientDataStorageAdapter)
+        {
+            _webApiCapabilityService = webApiCapabilityService;
+            _clientDataStorageAdapter = clientDataStorageAdapter;
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> HasStoredClientDataAsync(CancellationToken cancellationToken = default)
+        {
+            var capabilityState = await _webApiCapabilityService.GetCapabilityStateAsync(cancellationToken);
+            if (!capabilityState.SupportsClientData)
+            {
+                return false;
+            }
+
+            try
+            {
+                var loadResult = await _clientDataStorageAdapter.LoadPrefixedEntriesAsync(cancellationToken);
+                return loadResult.Succeeded
+                    && loadResult.Entries is not null
+                    && loadResult.Entries.Count > 0;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Lantean.QBTMud.Application/Services/IClientDataPresenceService.cs
+++ b/src/Lantean.QBTMud.Application/Services/IClientDataPresenceService.cs
@@ -1,0 +1,15 @@
+namespace Lantean.QBTMud.Application.Services
+{
+    /// <summary>
+    /// Detects whether qbtmud-owned ClientData already exists for the current qBittorrent instance.
+    /// </summary>
+    public interface IClientDataPresenceService
+    {
+        /// <summary>
+        /// Determines whether any qbtmud-owned ClientData entries are already stored.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for the request.</param>
+        /// <returns><see langword="true"/> when qbtmud ClientData entries exist; otherwise, <see langword="false"/>.</returns>
+        Task<bool> HasStoredClientDataAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Lantean.QBTMud.Presentation/Components/Dialogs/WelcomeWizardDialog.razor
+++ b/src/Lantean.QBTMud.Presentation/Components/Dialogs/WelcomeWizardDialog.razor
@@ -187,6 +187,17 @@
                                             Subtitle="@LanguageLocalizer.Translate("AppWelcomeWizard", "Choose how qbtmud stores your settings data.")"
                                             AlertSeverity="Severity.Info"
                                             AlertText="@LanguageLocalizer.Translate("AppWelcomeWizard", "You can customize storage per group and per item later in App Settings.")">
+                                    @if (_shouldShowStoredClientDataNotice)
+                                    {
+                                        <MudAlert Severity="Severity.Info"
+                                                  Variant="Variant.Outlined"
+                                                  Dense="true"
+                                                  Class="mb-4"
+                                                  data-test-id="@TestIdHelper.For("WelcomeWizardStoredClientDataAlert")">
+                                            @LanguageLocalizer.Translate("AppWelcomeWizard", "qBittorrent client data was selected because qbtmud settings were found in this qBittorrent instance. Change this if you prefer browser local storage.")
+                                        </MudAlert>
+                                    }
+
                                     <MudRadioGroup T="StorageType"
                                                    Value="_storageSelection"
                                                    ValueChanged="OnStorageSelectionChanged"

--- a/src/Lantean.QBTMud.Presentation/Components/Dialogs/WelcomeWizardDialog.razor.cs
+++ b/src/Lantean.QBTMud.Presentation/Components/Dialogs/WelcomeWizardDialog.razor.cs
@@ -48,6 +48,9 @@ namespace Lantean.QBTMud.Components.Dialogs
         protected IStorageRoutingService StorageRoutingService { get; set; } = default!;
 
         [Inject]
+        protected IClientDataPresenceService ClientDataPresenceService { get; set; } = default!;
+
+        [Inject]
         protected IWelcomeWizardStateService WelcomeWizardStateService { get; set; } = default!;
 
         [Inject]
@@ -85,6 +88,7 @@ namespace Lantean.QBTMud.Components.Dialogs
         private StorageType _localThemeStorageType = StorageType.LocalStorage;
         private StorageType _storageSelection = StorageType.LocalStorage;
         private StorageRoutingSettings _storageRoutingSettings = StorageRoutingSettings.Default.Clone();
+        private bool _shouldShowStoredClientDataNotice;
         private bool _keyboardFocused;
         private bool _disposedValue;
 
@@ -224,6 +228,7 @@ namespace Lantean.QBTMud.Components.Dialogs
             _settings = await AppSettingsService.GetSettingsAsync();
             _storageRoutingSettings = await StorageRoutingService.GetSettingsAsync();
             _storageSelection = NormalizeStorageType(_storageRoutingSettings.MasterStorageType);
+            await ApplyStoredClientDataRecommendationAsync();
 
             _notificationPermission = await GetNotificationPermissionSafeAsync();
 
@@ -723,6 +728,27 @@ namespace Lantean.QBTMud.Components.Dialogs
         private void OnStorageSelectionChanged(StorageType value)
         {
             _storageSelection = NormalizeStorageType(value);
+        }
+
+        private async Task ApplyStoredClientDataRecommendationAsync()
+        {
+            if (!ResolvePendingStepIds().Contains(WelcomeWizardStepCatalog.StorageStepId, StringComparer.Ordinal))
+            {
+                return;
+            }
+
+            if (_storageSelection == StorageType.ClientData)
+            {
+                return;
+            }
+
+            if (!await ClientDataPresenceService.HasStoredClientDataAsync())
+            {
+                return;
+            }
+
+            _storageSelection = StorageType.ClientData;
+            _shouldShowStoredClientDataNotice = true;
         }
 
         private async Task<bool> ApplyPendingThemeSelectionAsync()

--- a/src/Lantean.QBTMud/wwwroot/i18n/webui_overrides_en.json
+++ b/src/Lantean.QBTMud/wwwroot/i18n/webui_overrides_en.json
@@ -601,6 +601,7 @@
   "AppWelcomeWizard|Stored with this qBittorrent WebUI session data.": "Stored with this qBittorrent WebUI session data.",
   "AppWelcomeWizard|Best for single-browser setups on one device.": "Best for single-browser setups on one device.",
   "AppWelcomeWizard|Settings stay in this browser profile.": "Settings stay in this browser profile.",
+  "AppWelcomeWizard|qBittorrent client data was selected because qbtmud settings were found in this qBittorrent instance. Change this if you prefer browser local storage.": "qBittorrent client data was selected because qbtmud settings were found in this qBittorrent instance. Change this if you prefer browser local storage.",
   "AppWelcomeWizard|Storage: %1": "Storage: %1",
   "AppWelcomeWizard|Select a storage type to continue.": "Select a storage type to continue."
 }

--- a/test/Lantean.QBTMud.Application.Test/Services/ClientDataPresenceServiceTests.cs
+++ b/test/Lantean.QBTMud.Application.Test/Services/ClientDataPresenceServiceTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using Lantean.QBTMud.Core.Models;
+using Moq;
+using QBittorrent.ApiClient;
+
+namespace Lantean.QBTMud.Application.Test.Services
+{
+    public sealed class ClientDataPresenceServiceTests
+    {
+        private readonly IWebApiCapabilityService _webApiCapabilityService;
+        private readonly IClientDataStorageAdapter _clientDataStorageAdapter;
+        private readonly ClientDataPresenceService _target;
+
+        public ClientDataPresenceServiceTests()
+        {
+            _webApiCapabilityService = Mock.Of<IWebApiCapabilityService>();
+            _clientDataStorageAdapter = Mock.Of<IClientDataStorageAdapter>();
+            _target = new ClientDataPresenceService(_webApiCapabilityService, _clientDataStorageAdapter);
+        }
+
+        [Fact]
+        public async Task GIVEN_ClientDataUnsupported_WHEN_HasStoredClientDataInvoked_THEN_ShouldReturnFalse()
+        {
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 12, 0), false));
+
+            var result = await _target.HasStoredClientDataAsync(Xunit.TestContext.Current.CancellationToken);
+
+            result.Should().BeFalse();
+            Mock.Get(_clientDataStorageAdapter)
+                .Verify(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GIVEN_ClientDataSupportedWithoutEntries_WHEN_HasStoredClientDataInvoked_THEN_ShouldReturnFalse()
+        {
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
+            Mock.Get(_clientDataStorageAdapter)
+                .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ClientDataLoadResult.FromEntries(new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
+
+            var result = await _target.HasStoredClientDataAsync(Xunit.TestContext.Current.CancellationToken);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GIVEN_ClientDataSupportedWithEntries_WHEN_HasStoredClientDataInvoked_THEN_ShouldReturnTrue()
+        {
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
+            Mock.Get(_clientDataStorageAdapter)
+                .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ClientDataLoadResult.FromEntries(
+                    new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+                    {
+                        ["QbtMud.AppSettings.State.v2"] = JsonDocument.Parse("{\"notificationsEnabled\":true}").RootElement.Clone()
+                    }));
+
+            var result = await _target.HasStoredClientDataAsync(Xunit.TestContext.Current.CancellationToken);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GIVEN_ClientDataLoadFails_WHEN_HasStoredClientDataInvoked_THEN_ShouldReturnFalse()
+        {
+            var failure = CreateFailureResult();
+
+            Mock.Get(_webApiCapabilityService)
+                .Setup(service => service.GetCapabilityStateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new WebApiCapabilityState(new Version(2, 13, 1), true));
+            Mock.Get(_clientDataStorageAdapter)
+                .Setup(adapter => adapter.LoadPrefixedEntriesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ClientDataLoadResult.FromFailure(failure));
+
+            var result = await _target.HasStoredClientDataAsync(Xunit.TestContext.Current.CancellationToken);
+
+            result.Should().BeFalse();
+        }
+
+        private static ApiResult CreateFailureResult()
+        {
+            return ApiResult.CreateFailure(new ApiFailure
+            {
+                Kind = ApiFailureKind.ServerError,
+                Operation = "Operation",
+                UserMessage = "Failure"
+            });
+        }
+    }
+}

--- a/test/Lantean.QBTMud.Presentation.Test/Components/Dialogs/WelcomeWizardDialogTests.cs
+++ b/test/Lantean.QBTMud.Presentation.Test/Components/Dialogs/WelcomeWizardDialogTests.cs
@@ -29,6 +29,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
         private readonly ILanguageInitializationService _languageInitializationService = Mock.Of<ILanguageInitializationService>();
         private readonly IAppSettingsService _appSettingsService = Mock.Of<IAppSettingsService>();
         private readonly IBrowserNotificationService _browserNotificationService = Mock.Of<IBrowserNotificationService>();
+        private readonly IClientDataPresenceService _clientDataPresenceService = Mock.Of<IClientDataPresenceService>();
         private readonly IWelcomeWizardStateService _welcomeWizardStateService = Mock.Of<IWelcomeWizardStateService>();
         private readonly IKeyboardService _keyboardService;
         private readonly Mock<IKeyboardService> _keyboardServiceMock;
@@ -112,6 +113,9 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
             Mock.Get(_browserNotificationService)
                 .Setup(service => service.UnsubscribePermissionChangesAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
+            Mock.Get(_clientDataPresenceService)
+                .Setup(service => service.HasStoredClientDataAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
             Mock.Get(_welcomeWizardStateService)
                 .Setup(service => service.AcknowledgeStepsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new WelcomeWizardState());
@@ -134,6 +138,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
             TestContext.Services.RemoveAll<IKeyboardService>();
             TestContext.Services.RemoveAll<IAppSettingsService>();
             TestContext.Services.RemoveAll<IBrowserNotificationService>();
+            TestContext.Services.RemoveAll<IClientDataPresenceService>();
             TestContext.Services.RemoveAll<IWelcomeWizardStateService>();
 
             TestContext.Services.AddSingleton(_apiClient);
@@ -145,6 +150,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
             TestContext.Services.AddSingleton(_keyboardService);
             TestContext.Services.AddSingleton(_appSettingsService);
             TestContext.Services.AddSingleton(_browserNotificationService);
+            TestContext.Services.AddSingleton(_clientDataPresenceService);
             TestContext.Services.AddSingleton(_welcomeWizardStateService);
 
             _target = new WelcomeWizardDialogTestDriver(TestContext);
@@ -1871,7 +1877,7 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
         }
 
         [Fact]
-        public async Task GIVEN_StorageStep_WHEN_Rendered_THEN_BrowserLocalStorageIsSelectedAndNextIsEnabled()
+        public async Task GIVEN_StorageStepWithoutStoredClientData_WHEN_Rendered_THEN_BrowserLocalStorageIsSelectedAndNextIsEnabled()
         {
             var dialog = await _target.RenderDialogAsync(
                 pendingStepIds: new[]
@@ -1884,6 +1890,33 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
 
             storageSelection.Instance.Value.Should().Be(StorageType.LocalStorage);
             nextButton.Instance.Disabled.Should().BeFalse();
+            dialog.Component.FindComponents<MudAlert>()
+                .Any(component => HasTestId(component, "WelcomeWizardStoredClientDataAlert"))
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GIVEN_StorageStepWithStoredClientData_WHEN_Rendered_THEN_ClientDataIsSelectedAndNoticeIsShown()
+        {
+            var clientDataPresenceService = new Mock<IClientDataPresenceService>(MockBehavior.Strict);
+            clientDataPresenceService
+                .Setup(service => service.HasStoredClientDataAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            TestContext.Services.RemoveAll<IClientDataPresenceService>();
+            TestContext.Services.AddSingleton<IClientDataPresenceService>(clientDataPresenceService.Object);
+
+            var dialog = await _target.RenderDialogAsync(
+                pendingStepIds: new[]
+                {
+                    WelcomeWizardStepCatalog.StorageStepId
+                });
+
+            var storageSelection = FindComponentByTestId<MudRadioGroup<StorageType>>(dialog.Component, "WelcomeWizardStorageSelection");
+            var alert = FindComponentByTestId<MudAlert>(dialog.Component, "WelcomeWizardStoredClientDataAlert");
+
+            storageSelection.Instance.Value.Should().Be(StorageType.ClientData);
+            GetChildContentText(alert.Instance.ChildContent).Should().Be("qBittorrent client data was selected because qbtmud settings were found in this qBittorrent instance. Change this if you prefer browser local storage.");
         }
 
         [Fact]
@@ -1924,6 +1957,39 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
 
             var storageSelection = FindComponentByTestId<MudRadioGroup<StorageType>>(dialog.Component, "WelcomeWizardStorageSelection");
             storageSelection.Instance.Value.Should().Be(StorageType.LocalStorage);
+        }
+
+        [Fact]
+        public async Task GIVEN_StorageStepWithPersistedClientDataRouting_WHEN_Rendered_THEN_ClientDataRemainsSelectedWithoutNotice()
+        {
+            var storageRoutingService = new Mock<IStorageRoutingService>(MockBehavior.Strict);
+            storageRoutingService
+                .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new StorageRoutingSettings
+                {
+                    MasterStorageType = StorageType.ClientData
+                });
+
+            var clientDataPresenceService = new Mock<IClientDataPresenceService>(MockBehavior.Strict);
+
+            TestContext.Services.RemoveAll<IStorageRoutingService>();
+            TestContext.Services.AddSingleton<IStorageRoutingService>(storageRoutingService.Object);
+            TestContext.Services.RemoveAll<IClientDataPresenceService>();
+            TestContext.Services.AddSingleton<IClientDataPresenceService>(clientDataPresenceService.Object);
+
+            var dialog = await _target.RenderDialogAsync(
+                pendingStepIds: new[]
+                {
+                    WelcomeWizardStepCatalog.StorageStepId
+                });
+
+            var storageSelection = FindComponentByTestId<MudRadioGroup<StorageType>>(dialog.Component, "WelcomeWizardStorageSelection");
+
+            storageSelection.Instance.Value.Should().Be(StorageType.ClientData);
+            dialog.Component.FindComponents<MudAlert>()
+                .Any(component => HasTestId(component, "WelcomeWizardStoredClientDataAlert"))
+                .Should().BeFalse();
+            clientDataPresenceService.Verify(service => service.HasStoredClientDataAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]
@@ -2006,6 +2072,99 @@ namespace Lantean.QBTMud.Presentation.Test.Components.Dialogs
                 {
                     WelcomeWizardStepCatalog.StorageStepId
                 });
+
+            var nextButton = FindButton(dialog.Component, "WelcomeWizardNext");
+            await nextButton.Find("button").ClickAsync(new MouseEventArgs());
+            var finishButton = FindButton(dialog.Component, "WelcomeWizardFinish");
+            await finishButton.Find("button").ClickAsync(new MouseEventArgs());
+
+            var result = await dialog.Reference.Result;
+            result!.Canceled.Should().BeFalse();
+
+            storageRoutingService.Verify(
+                service => service.SaveSettingsAsync(
+                    It.Is<StorageRoutingSettings>(settings =>
+                        settings.MasterStorageType == StorageType.LocalStorage
+                        && settings.GroupStorageTypes.Count == 0
+                        && settings.ItemStorageTypes.Count == 0),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GIVEN_StorageStepWithStoredClientData_WHEN_FinishClicked_THEN_AppliesClientDataSelection()
+        {
+            var storageRoutingService = new Mock<IStorageRoutingService>(MockBehavior.Strict);
+            storageRoutingService
+                .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StorageRoutingSettings.Default);
+            storageRoutingService
+                .Setup(service => service.SaveSettingsAsync(It.IsAny<StorageRoutingSettings>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((StorageRoutingSettings settings, CancellationToken _) => settings.Clone());
+
+            var clientDataPresenceService = new Mock<IClientDataPresenceService>(MockBehavior.Strict);
+            clientDataPresenceService
+                .Setup(service => service.HasStoredClientDataAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            TestContext.Services.RemoveAll<IStorageRoutingService>();
+            TestContext.Services.AddSingleton<IStorageRoutingService>(storageRoutingService.Object);
+            TestContext.Services.RemoveAll<IClientDataPresenceService>();
+            TestContext.Services.AddSingleton<IClientDataPresenceService>(clientDataPresenceService.Object);
+
+            var dialog = await _target.RenderDialogAsync(
+                pendingStepIds: new[]
+                {
+                    WelcomeWizardStepCatalog.StorageStepId
+                });
+
+            var nextButton = FindButton(dialog.Component, "WelcomeWizardNext");
+            await nextButton.Find("button").ClickAsync(new MouseEventArgs());
+            var finishButton = FindButton(dialog.Component, "WelcomeWizardFinish");
+            await finishButton.Find("button").ClickAsync(new MouseEventArgs());
+
+            var result = await dialog.Reference.Result;
+            result!.Canceled.Should().BeFalse();
+
+            storageRoutingService.Verify(
+                service => service.SaveSettingsAsync(
+                    It.Is<StorageRoutingSettings>(settings =>
+                        settings.MasterStorageType == StorageType.ClientData
+                        && settings.GroupStorageTypes.Count == 0
+                        && settings.ItemStorageTypes.Count == 0),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GIVEN_StorageStepWithStoredClientData_WHEN_LocalStorageSelectedBeforeFinish_THEN_AppliesLocalStorageSelection()
+        {
+            var storageRoutingService = new Mock<IStorageRoutingService>(MockBehavior.Strict);
+            storageRoutingService
+                .Setup(service => service.GetSettingsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StorageRoutingSettings.Default);
+            storageRoutingService
+                .Setup(service => service.SaveSettingsAsync(It.IsAny<StorageRoutingSettings>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((StorageRoutingSettings settings, CancellationToken _) => settings.Clone());
+
+            var clientDataPresenceService = new Mock<IClientDataPresenceService>(MockBehavior.Strict);
+            clientDataPresenceService
+                .Setup(service => service.HasStoredClientDataAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            TestContext.Services.RemoveAll<IStorageRoutingService>();
+            TestContext.Services.AddSingleton<IStorageRoutingService>(storageRoutingService.Object);
+            TestContext.Services.RemoveAll<IClientDataPresenceService>();
+            TestContext.Services.AddSingleton<IClientDataPresenceService>(clientDataPresenceService.Object);
+
+            var dialog = await _target.RenderDialogAsync(
+                pendingStepIds: new[]
+                {
+                    WelcomeWizardStepCatalog.StorageStepId
+                });
+
+            var storageSelection = FindComponentByTestId<MudRadioGroup<StorageType>>(dialog.Component, "WelcomeWizardStorageSelection");
+            await dialog.Component.InvokeAsync(() => storageSelection.Instance.ValueChanged.InvokeAsync(StorageType.LocalStorage));
 
             var nextButton = FindButton(dialog.Component, "WelcomeWizardNext");
             await nextButton.Find("button").ClickAsync(new MouseEventArgs());


### PR DESCRIPTION
## Summary

Make the welcome wizard detect existing qbtmud ClientData for the current qBittorrent instance so a new browser can resume server-backed settings automatically.

## What Changed

- Added a `ClientDataPresenceService` to detect whether qbtmud-owned ClientData already exists for the current server.
- Updated the welcome wizard storage step to preselect `qBittorrent client data` when stored ClientData is found and the browser has not already chosen ClientData routing.
- Added an informational storage-step alert explaining that ClientData was selected automatically because existing qbtmud settings were found.
- Added English override copy for the new wizard notice.

## Testing

- Added unit tests for ClientData presence detection covering unsupported ClientData, empty ClientData, existing ClientData, and failed ClientData loads.
- Added welcome wizard component tests covering default local-storage selection, automatic ClientData selection, persisted ClientData routing, and manual override back to local storage.
- Validated with `dotnet test Lantean.QBTMud.slnx --no-restore --artifacts-path=/tmp/artifacts/qbtmud`.

## Notes

- Existing settings are detected from any `QbtMud.*` ClientData entry.
- The detection is advisory and only affects the welcome wizard’s initial storage selection.
